### PR TITLE
Fix 32 bit compilation errors

### DIFF
--- a/iota-streams-app/src/message/pcf.rs
+++ b/iota-streams-app/src/message/pcf.rs
@@ -57,17 +57,17 @@ impl PCF<()> {
     }
 }
 
-fn payload_frame_num_from(n: usize) -> Result<NBytes<U3>> {
+fn payload_frame_num_from(n: u32) -> Result<NBytes<U3>> {
     ensure!(n < 0x400000, "Payload frame num out of range: {}", n);
     let v = n.to_be_bytes();
-    let g = <GenericArray<u8, U3>>::from_slice(&v[5..]);
+    let g = <GenericArray<u8, U3>>::from_slice(&v[1..]);
     Ok(NBytes::from(*g))
 }
 
-fn payload_frame_num_to(v: &NBytes<U3>) -> usize {
-    let mut u = [0_u8; 8];
-    u[5..].copy_from_slice(v.as_ref());
-    usize::from_be_bytes(u)
+fn payload_frame_num_to(v: &NBytes<U3>) -> u32 {
+    let mut u = [0_u8; 4];
+    u[1..].copy_from_slice(v.as_ref());
+    u32::from_be_bytes(u)
 }
 
 fn payload_frame_num_check(v: &NBytes<U3>) -> Result<()> {
@@ -76,7 +76,7 @@ fn payload_frame_num_check(v: &NBytes<U3>) -> Result<()> {
 }
 
 impl<Content> PCF<Content> {
-    pub fn new(frame_type: Uint8, payload_frame_num: usize, content: Content) -> Result<Self> {
+    pub fn new(frame_type: Uint8, payload_frame_num: u32, content: Content) -> Result<Self> {
         payload_frame_num_from(payload_frame_num).map(|payload_frame_num| Self {
             frame_type,
             payload_frame_num,
@@ -84,7 +84,7 @@ impl<Content> PCF<Content> {
         })
     }
 
-    pub fn with_payload_frame_num(mut self, payload_frame_num: usize) -> Result<Self> {
+    pub fn with_payload_frame_num(mut self, payload_frame_num: u32) -> Result<Self> {
         payload_frame_num_from(payload_frame_num).map(|payload_frame_num| {
             self.payload_frame_num = payload_frame_num;
             self
@@ -101,7 +101,7 @@ impl<Content> PCF<Content> {
         }
     }
 
-    pub fn get_payload_frame_num(&self) -> usize {
+    pub fn get_payload_frame_num(&self) -> u32 {
         payload_frame_num_to(&self.payload_frame_num)
     }
 }

--- a/iota-streams-app/src/transport/tangle/client.rs
+++ b/iota-streams-app/src/transport/tangle/client.rs
@@ -270,7 +270,7 @@ pub fn msg_from_bundle<F>(bundle: &Bundle) -> TangleMessage<F> {
 
     let binary = BinaryMessage::new(TangleAddress { appinst, msgid }, body.into());
     // let timestamp: u64 = *(tx.timestamp() as *const iota::bundle::Timestamp) as *const u64;
-    let timestamp: u64 = unsafe { core::mem::transmute(tx.timestamp()) };
+    let timestamp: u64 = unsafe { core::mem::transmute(tx.timestamp().clone()) };
 
     TangleMessage { binary, timestamp }
 }


### PR DESCRIPTION
# Description of change
Update HDF and PCF to use u32 instead of usize to fix 32 bit compiler errors on raspberry pi's. 
fixes #41 

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested
- Built on raspberry pi 
- Continues to build on windows and debian distros

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
