### PR TITLE
Updated docs to 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ fn main() {
 }
 ```
 
- For a more detailed guide, go to our [documentation portal](https://docs.iota.org/docs/channels/1.2/overview).
+ For a more detailed guide, go to our [documentation portal](https://docs.iota.org/docs/channels/1.3/overview).
 
 ## API reference
 


### PR DESCRIPTION
Small documentation change. The documentation was linking to 1.2 instead of 1.3.

A permanent fix would be if the url `https://docs.iota.org/docs/channels/` would link to the latest documentation. 