### PR TITLE
WIP: Better wasm debug

### DIFF
--- a/iota-streams-app-channels/src/api/tangle/mod.rs
+++ b/iota-streams-app-channels/src/api/tangle/mod.rs
@@ -84,13 +84,18 @@ pub type BucketTransport = transport::BucketTransport<Address, Message>;
 /// Transportation trait for Tangle Client implementation
 // TODO: Use trait synonyms `pub Transport = transport::Transport<DefaultF, Address>;`.
 pub trait Transport: transport::Transport<Address, Message> {}
-impl<T> Transport for T where T: transport::Transport<Address, Message> {}
+// impl<T> Transport for T where T: transport::Transport<Address, Message> {}
+impl Transport for transport::SharedTransport<BucketTransport> {}
+
+#[cfg(any(feature = "sync-client", feature = "async-client", feature = "wasm-client"))]
+impl Transport for iota_streams_app::transport::tangle::client::Client {}
 
 mod msginfo;
 pub use msginfo::MsgInfo;
 
 /// Message body returned as part of handle message routine.
 #[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
 pub enum MessageContent {
     Announce,
     Keyload,

--- a/iota-streams-app/src/transport/bucket.rs
+++ b/iota-streams-app/src/transport/bucket.rs
@@ -107,3 +107,47 @@ where
         }
     }
 }
+
+#[cfg(feature = "async")]
+#[async_trait(?Send)]
+impl<Link, Msg> Transport<Link, Msg> for Arc<AtomicRefCell<BucketTransport<Link, Msg>>> where
+    // Link: 'static + core::marker::Send + core::marker::Sync,
+    // Msg: 'static + core::marker::Send + core::marker::Sync,
+    Link: Eq + hash::Hash + Clone + core::marker::Send + core::marker::Sync + core::fmt::Display,
+    Msg: LinkedMessage<Link> + Clone + core::marker::Send + core::marker::Sync + core::fmt::Debug,
+{
+    /// Send a message.
+    async fn send_message(&mut self, msg: &Msg) -> Result<()> {
+        // assert!(false);
+        let bucket = &mut (&*self).borrow_mut().bucket;
+        if let Some(msgs) = bucket.get_mut(msg.link()) {
+            msgs.push(msg.clone());
+            Ok(())
+        } else {
+            bucket.insert(msg.link().clone(), vec![msg.clone()]);
+            Ok(())
+        }
+    }
+
+    /// Receive messages with default options.
+    async fn recv_messages(&mut self, link: &Link) -> Result<Vec<Msg>> {
+        let bucket = &(&*self).borrow().bucket;
+        if let Some(msgs) = bucket.get(link) {
+            Ok(msgs.clone())
+        } else {
+            err!(MessageLinkNotFound(link.to_string()))
+        }
+    }
+
+    /// Receive a message with default options.
+    async fn recv_message(&mut self, link: &Link) -> Result<Msg> {
+        let bucket = &(&*self).borrow().bucket;
+        if let Some(msgs) = bucket.get(link) {
+            try_or!(!msgs.is_empty(), MessageLinkNotFound(link.to_string()))?;
+            try_or!(1 == msgs.len(), MessageNotUnique(link.to_string()))?;
+            Ok(msgs[0].clone())
+        } else {
+            err!(MessageLinkNotFound(link.to_string()))
+        }
+    }
+}

--- a/iota-streams-app/src/transport/tangle/mod.rs
+++ b/iota-streams-app/src/transport/tangle/mod.rs
@@ -121,6 +121,12 @@ impl<F> TangleMessage<F> {
     }
 }
 
+impl<F> fmt::Debug for TangleMessage<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.binary)
+    }
+}
+
 impl<F> TangleMessage<F> {
     /// Create TangleMessage from BinaryMessage and an explicit timestamp.
     pub fn with_timestamp(msg: BinaryMessage<F, TangleAddress>, timestamp: u64) -> Self {

--- a/iota-streams-core/Cargo.toml
+++ b/iota-streams-core/Cargo.toml
@@ -30,5 +30,8 @@ anyhow = { version = "1.0.34", default-features = false, optional = false }
 # thiserror = { version = "1.0.22", default-features = false, optional = false }
 displaydoc = { version = "0.2", default-features = false, optional = false }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-sys = { version = "0.3", features = ["console"] }
+
 [dev-dependencies]
 criterion = "0.3"

--- a/iota-streams-core/src/errors/error_messages.rs
+++ b/iota-streams-core/src/errors/error_messages.rs
@@ -62,10 +62,10 @@ pub enum Errors {
     //////////
     /// More than one message found: with link {0}
     MessageNotUnique(String),
-    /// Message at link {0} not found in store
-    MessageLinkNotFound(String),
     /// Message at link {0} not found in tangle
-    MessageLinkNotFoundInTangle(String),
+    MessageLinkNotFound(String),
+    /// Message at link {0} not found in store
+    MessageLinkNotFoundInStore(String),
     /// Transport object is already borrowed
     TransportNotAvailable,
 

--- a/iota-streams-core/src/lib.rs
+++ b/iota-streams-core/src/lib.rs
@@ -11,7 +11,7 @@ extern crate std;
 
 // Stub used in tests & examples.
 // Macros are exported at crate root level, that's why it's defined here, not in `prelude` mod.
-#[cfg(not(feature = "std"))]
+#[cfg(not(any(target_arch = "wasm32", feature = "std")))]
 #[macro_export]
 macro_rules! println {
     () => {};
@@ -29,8 +29,21 @@ macro_rules! print {
     };
 }
 
+#[cfg(target_arch = "wasm32")]
+pub use web_sys;
+
+// You need to override `std::println` imported by default with
+// `use iota_streams::core::println;` in your mod.
+#[cfg(target_arch = "wasm32")]
+#[macro_export]
+macro_rules! println {
+    ( $( $arg:tt )* ) => {
+        $crate::web_sys::console::log_1(&$crate::format!( $( $arg )* ).into());
+    }
+}
+
 // Reexport macro at the same level as `no_std`.
-#[cfg(feature = "std")]
+#[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
 pub use std::println;
 
 #[cfg(feature = "std")]

--- a/iota-streams-ddml/src/command/unwrap/dump.rs
+++ b/iota-streams-ddml/src/command/unwrap/dump.rs
@@ -17,7 +17,7 @@ impl<F: PRP, IS: io::IStream> Dump for Context<F, IS> {
         // println!("dump: {}", args,);
 
         //#[cfg(test)]
-        println!(
+        iota_streams_core::println!(
             "dump: {}: istream=[{}] spongos=[{:?}]",
             args,
             self.stream.dump(),

--- a/iota-streams-ddml/src/command/wrap/dump.rs
+++ b/iota-streams-ddml/src/command/wrap/dump.rs
@@ -17,7 +17,7 @@ impl<F: PRP, OS: io::OStream> Dump for Context<F, OS> {
         // println!("dump: {}", args,);
 
         //#[cfg(test)]
-        println!(
+        iota_streams_core::println!(
             "dump: {}: ostream=[{}] spongos=[{:?}]",
             args,
             self.stream.dump(),

--- a/iota-streams-ddml/src/link_store.rs
+++ b/iota-streams-ddml/src/link_store.rs
@@ -1,7 +1,7 @@
 use core::hash;
 use iota_streams_core::Result;
 
-use core::fmt::Display;
+use core::fmt::{Debug, Display};
 use iota_streams_core::{
     err,
     prelude::{
@@ -19,7 +19,7 @@ use iota_streams_core::{
     try_or,
     Errors::{
         GenericLinkNotFound,
-        MessageLinkNotFoundInTangle,
+        MessageLinkNotFoundInStore,
     },
     LOCATION_LOG,
 };
@@ -115,7 +115,7 @@ where
 {
     type Info = Info;
     fn lookup(&self, link: &Link) -> Result<(Spongos<F>, Self::Info)> {
-        try_or!(self.link() == link, MessageLinkNotFoundInTangle(link.to_string()))?;
+        try_or!(self.link() == link, MessageLinkNotFoundInStore(link.to_string()))?;
         Ok((self.spongos().into(), self.info().clone()))
     }
     fn update(&mut self, link: &Link, spongos: Spongos<F>, info: Self::Info) -> Result<()> {
@@ -155,7 +155,7 @@ where
 
 impl<F: PRP, Link, Info> LinkStore<F, Link> for DefaultLinkStore<F, Link, Info>
 where
-    Link: Eq + hash::Hash + Clone + Display,
+    Link: Eq + hash::Hash + Clone + Display + Debug,
     Info: Clone,
 {
     type Info = Info;
@@ -164,7 +164,7 @@ where
     fn lookup(&self, link: &Link) -> Result<(Spongos<F>, Info)> {
         match self.map.get(link) {
             Some((inner, info)) => Ok((inner.into(), info.clone())),
-            None => err!(MessageLinkNotFoundInTangle(link.to_string())),
+            None => err!(MessageLinkNotFoundInStore(link.to_string())),
         }
     }
 


### PR DESCRIPTION
# Description of change

Changes to ease debug wasm bindings:
- println! macro now works via web_sys.console,
- BucketTransport now impls async Transport.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

With node.js examples: now it's possible to use BucketTransport (with some tricks) in node.js examples that makes tests reproducible with the same seed and much faster, debug output with `iota_streams::core::println!` in rust code is now shown in the console.

TODO: Add wasm bindings for SharedBucketTransport.
TODO: Provide examples for how to use it in node.js.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
