### PR TITLE
Improved Psk Usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
 
 [[package]]
+name = "ahash"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+dependencies = [
+ "getrandom 0.2.3",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,7 +1032,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
 dependencies = [
- "ahash",
+ "ahash 0.3.8",
  "autocfg",
 ]
 
@@ -1030,6 +1041,15 @@ name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash 0.7.4",
+]
 
 [[package]]
 name = "heck"
@@ -1315,7 +1335,7 @@ dependencies = [
  "criterion",
  "digest 0.9.0",
  "displaydoc",
- "hashbrown 0.8.2",
+ "hashbrown 0.11.2",
  "hex",
  "iota-crypto 0.6.0",
  "rand 0.7.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,7 +1201,7 @@ dependencies = [
  "bee-rest-api",
  "futures",
  "hex",
- "iota-crypto 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iota-crypto 0.5.1",
  "log",
  "num_cpus",
  "regex",
@@ -1245,8 +1245,8 @@ dependencies = [
 
 [[package]]
 name = "iota-crypto"
-version = "0.5.1"
-source = "git+https://github.com/iotaledger/crypto.rs?branch=dev#7b9cac4c0aafddc9022f38320b8127af3c58495c"
+version = "0.6.0"
+source = "git+https://github.com/iotaledger/crypto.rs?branch=dev#e42be4d028edc520a3d71b5f37bf37f5a128dc32"
 dependencies = [
  "blake2",
  "digest 0.9.0",
@@ -1277,7 +1277,6 @@ dependencies = [
  "futures",
  "hex",
  "iota-client",
- "iota-crypto 0.5.1 (git+https://github.com/iotaledger/crypto.rs?branch=dev)",
  "iota-streams-core",
  "iota-streams-core-edsig",
  "iota-streams-ddml",
@@ -1318,6 +1317,7 @@ dependencies = [
  "displaydoc",
  "hashbrown 0.8.2",
  "hex",
+ "iota-crypto 0.6.0",
  "rand 0.7.3",
 ]
 

--- a/bindings/c/Cargo.lock
+++ b/bindings/c/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
 
 [[package]]
+name = "ahash"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+dependencies = [
+ "getrandom 0.2.2",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,7 +671,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
 dependencies = [
- "ahash",
+ "ahash 0.3.8",
  "autocfg",
 ]
 
@@ -669,6 +680,15 @@ name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash 0.7.4",
+]
 
 [[package]]
 name = "heck"
@@ -865,7 +885,7 @@ dependencies = [
  "anyhow",
  "digest 0.9.0",
  "displaydoc",
- "hashbrown 0.8.2",
+ "hashbrown 0.11.2",
  "hex",
  "iota-crypto 0.5.1 (git+https://github.com/iotaledger/crypto.rs?branch=dev)",
  "rand 0.7.3",

--- a/bindings/c/Cargo.lock
+++ b/bindings/c/Cargo.lock
@@ -840,7 +840,6 @@ dependencies = [
  "futures",
  "hex",
  "iota-client",
- "iota-crypto 0.5.1 (git+https://github.com/iotaledger/crypto.rs?branch=dev)",
  "iota-streams-core",
  "iota-streams-core-edsig",
  "iota-streams-ddml",
@@ -868,6 +867,7 @@ dependencies = [
  "displaydoc",
  "hashbrown 0.8.2",
  "hex",
+ "iota-crypto 0.5.1 (git+https://github.com/iotaledger/crypto.rs?branch=dev)",
  "rand 0.7.3",
 ]
 

--- a/bindings/c/include/iota_streams/channels.h
+++ b/bindings/c/include/iota_streams/channels.h
@@ -213,5 +213,6 @@ extern char const *get_address_index_str(address_t const *address);
 extern address_t const *get_link_from_state(user_state_t const *state, public_key_t const *pub_key);
 
 extern char const *pskid_as_str(psk_id_t const *pskid);
+extern void drop_pskid(psk_id_t const *pskid);
 
 #endif //IOTA_STREAMS_CHANNELS_H

--- a/bindings/c/include/iota_streams/channels.h
+++ b/bindings/c/include/iota_streams/channels.h
@@ -144,7 +144,7 @@ extern unwrapped_messages_t const *auth_fetch_next_msgs(author_t *author);
 extern unwrapped_messages_t const *auth_sync_state(author_t *author);
 extern user_state_t const * auth_fetch_state(author_t *author);
 // Store Psk
-extern pskid_t const *auth_store_psk(author_t *author, char const *psk);
+extern psk_id_t const *auth_store_psk(author_t *author, char const *psk);
 
 
 /////////////
@@ -189,7 +189,7 @@ extern err_t sub_fetch_next_msgs(unwrapped_messages_t const **messages, subscrib
 extern err_t sub_sync_state(unwrapped_messages_t const **messages, subscriber_t *subscriber);
 extern user_state_t const *sub_fetch_state(subscriber_t *subscriber);
 // Store Psk
-extern pskid_t const *sub_store_psk(subscriber_t *subscriber, char const *psk);
+extern psk_id_t const *sub_store_psk(subscriber_t *subscriber, char const *psk);
 
 /////////////
 /// Utility
@@ -212,6 +212,6 @@ extern char const *get_address_index_str(address_t const *address);
 
 extern address_t const *get_link_from_state(user_state_t const *state, public_key_t const *pub_key);
 
-extern char const *pskid_as_str(pskid_t const *pskid);
+extern char const *pskid_as_str(psk_id_t const *pskid);
 
 #endif //IOTA_STREAMS_CHANNELS_H

--- a/bindings/c/include/iota_streams/channels.h
+++ b/bindings/c/include/iota_streams/channels.h
@@ -176,7 +176,7 @@ extern err_t sub_receive_keyload_from_ids(message_links_t *links, subscriber_t *
 extern err_t sub_send_tagged_packet(message_links_t *links, subscriber_t *subscriber, message_links_t link_to, uint8_t const *public_payload_ptr, size_t public_payload_size, uint8_t const *masked_payload_ptr, size_t masked_payload_size);
 extern err_t sub_receive_tagged_packet(packet_payloads_t *payloads, subscriber_t *subscriber, address_t const *address);
 // Signed Packets
-//extern message_links_t *sub_send_signed_packet(subscriber_t *subscriber, message_links_t *link_to, char *public_payload, char *private_payload);
+extern err_t *sub_send_signed_packet(message_links_t *links, subscriber_t *subscriber, message_links_t *link_to, char *public_payload, char *private_payload);
 extern err_t sub_receive_signed_packet(packet_payloads_t *payloads, subscriber_t *subscriber, address_t const *address);
 // Sequence Message (for multi branch use)
 extern err_t sub_receive_sequence(address_t const **address, subscriber_t *subscriber, address_t const *seq_address);

--- a/bindings/c/include/iota_streams/channels.h
+++ b/bindings/c/include/iota_streams/channels.h
@@ -20,6 +20,7 @@ extern address_t *address_from_string(char const *addr_str);
 typedef struct ChannelAddress channel_address_t;
 typedef struct MsgId msgid_t;
 typedef struct PublicKey public_key_t;
+typedef struct PskId psk_id_t;
 typedef struct PskIds psk_ids_t;
 typedef struct KePks ke_pks_t;
 
@@ -142,6 +143,9 @@ extern err_t auth_receive_msg(unwrapped_message_t const **msg, author_t *author,
 extern unwrapped_messages_t const *auth_fetch_next_msgs(author_t *author);
 extern unwrapped_messages_t const *auth_sync_state(author_t *author);
 extern user_state_t const * auth_fetch_state(author_t *author);
+// Store Psk
+extern pskid_t const *auth_store_psk(author_t *author, char const *psk);
+
 
 /////////////
 // Subscriber
@@ -184,6 +188,8 @@ extern err_t sub_receive_msg(unwrapped_message_t const *umsg, subscriber_t *subs
 extern err_t sub_fetch_next_msgs(unwrapped_messages_t const **messages, subscriber_t *subscriber);
 extern err_t sub_sync_state(unwrapped_messages_t const **messages, subscriber_t *subscriber);
 extern user_state_t const *sub_fetch_state(subscriber_t *subscriber);
+// Store Psk
+extern pskid_t const *sub_store_psk(subscriber_t *subscriber, char const *psk);
 
 /////////////
 /// Utility
@@ -205,5 +211,7 @@ extern packet_payloads_t get_indexed_payload(unwrapped_messages_t const *message
 extern char const *get_address_index_str(address_t const *address);
 
 extern address_t const *get_link_from_state(user_state_t const *state, public_key_t const *pub_key);
+
+extern char const *pskid_as_str(pskid_t const *pskid);
 
 #endif //IOTA_STREAMS_CHANNELS_H

--- a/bindings/c/src/api/auth.rs
+++ b/bindings/c/src/api/auth.rs
@@ -372,3 +372,16 @@ pub extern "C" fn auth_fetch_state(user: *mut Author) -> *const UserState {
         })
     }
 }
+
+#[no_mangle]
+pub extern "C" fn auth_store_psk(user: *mut Author, psk_str: *const c_char) -> *const PskId {
+    unsafe {
+        let psk = CStr::from_ptr(psk_str).to_str().unwrap();
+        user.as_mut().map_or(null(), |user| {
+            psk_from_str(psk).as_ref().map_or(null(),|psk| {
+                let pskid = user.store_psk(*psk);
+                safe_into_ptr(pskid)
+            })
+        })
+    }
+}

--- a/bindings/c/src/api/auth.rs
+++ b/bindings/c/src/api/auth.rs
@@ -374,14 +374,14 @@ pub extern "C" fn auth_fetch_state(user: *mut Author) -> *const UserState {
 }
 
 #[no_mangle]
-pub extern "C" fn auth_store_psk(user: *mut Author, psk_str: *const c_char) -> *const PskId {
+pub extern "C" fn auth_store_psk(user: *mut Author, psk_seed_str: *const c_char) -> *const PskId {
     unsafe {
-        let psk = CStr::from_ptr(psk_str).to_str().unwrap();
+        let psk_seed = CStr::from_ptr(psk_seed_str).to_str().unwrap();
         user.as_mut().map_or(null(), |user| {
-            psk_from_str(psk).as_ref().map_or(null(),|psk| {
-                let pskid = user.store_psk(*psk);
-                safe_into_ptr(pskid)
-            })
+            let psk = psk_from_seed(psk_seed.as_ref());
+            let pskid = pskid_from_psk(&psk);
+            user.store_psk(pskid.clone(), psk);
+            safe_into_ptr(pskid)
         })
     }
 }

--- a/bindings/c/src/api/auth.rs
+++ b/bindings/c/src/api/auth.rs
@@ -11,9 +11,9 @@ pub unsafe extern "C" fn auth_new(
     multi_branching: uint8_t,
     transport: *mut TransportWrap,
 ) -> *mut Author {
-    let seed = unsafe { CStr::from_ptr(c_seed).to_str().unwrap() };
-    let encoding = unsafe { CStr::from_ptr(c_encoding).to_str().unwrap() };
-    let tsp = unsafe { (*transport).clone() };
+    let seed = CStr::from_ptr(c_seed).to_str().unwrap();
+    let encoding = CStr::from_ptr(c_encoding).to_str().unwrap();
+    let tsp = (*transport).clone();
     let user = Author::new(seed, encoding, payload_length, multi_branching != 0, tsp);
     safe_into_mut_ptr(user)
 }
@@ -26,16 +26,14 @@ pub unsafe extern "C" fn auth_recover(
     multi_branching: uint8_t,
     transport: *mut TransportWrap
 ) -> *mut Author {
-    unsafe {
-        c_ann_address.as_ref().map_or(null_mut(), |addr| {
-            let seed = CStr::from_ptr(c_seed).to_str().unwrap();
-            let tsp = (*transport).clone();
-            Author::recover(seed, addr, multi_branching != 0, tsp)
-                .map_or(null_mut(), |auth| {
-                    safe_into_mut_ptr(auth)
-                })
-        })
-    }
+    c_ann_address.as_ref().map_or(null_mut(), |addr| {
+        let seed = CStr::from_ptr(c_seed).to_str().unwrap();
+        let tsp = (*transport).clone();
+        Author::recover(seed, addr, multi_branching != 0, tsp)
+            .map_or(null_mut(), |auth| {
+                safe_into_mut_ptr(auth)
+            })
+    })
 }
 
 /// Import an Author instance from an encrypted binary array
@@ -45,19 +43,17 @@ pub unsafe extern "C" fn auth_import(
     password: *const c_char,
     transport: *mut TransportWrap,
 ) -> *mut Author {
-    unsafe {
-        let bytes_vec = Vec::from_raw_parts(
-            buffer.ptr as *mut u8,
-            buffer.size,
-            buffer.cap,
-        );
-        let password_str = CStr::from_ptr(password).to_str().unwrap();
-        let tsp = (*transport).clone();
-        Author::import(&bytes_vec, password_str, tsp)
-            .map_or(null_mut(), |auth| {
-                Box::into_raw(Box::new(auth))
-        })
-    }
+    let bytes_vec = Vec::from_raw_parts(
+        buffer.ptr as *mut u8,
+        buffer.size,
+        buffer.cap,
+    );
+    let password_str = CStr::from_ptr(password).to_str().unwrap();
+    let tsp = (*transport).clone();
+    Author::import(&bytes_vec, password_str, tsp)
+        .map_or(null_mut(), |auth| {
+            Box::into_raw(Box::new(auth))
+    })
 }
 
 #[no_mangle]
@@ -65,13 +61,11 @@ pub unsafe extern "C" fn auth_export(
     user: *mut Author,
     password: *const c_char
 ) -> Buffer {
-    unsafe {
-        let password_str = CStr::from_ptr(password).to_str().unwrap();
-        user.as_ref().map_or(Buffer::default(), |user| {
-            let bytes = user.export(password_str).unwrap();
-            bytes.into()
-        })
-    }
+    let password_str = CStr::from_ptr(password).to_str().unwrap();
+    user.as_ref().map_or(Buffer::default(), |user| {
+        let bytes = user.export(password_str).unwrap();
+        bytes.into()
+    })
 }
 
 #[no_mangle]
@@ -82,47 +76,39 @@ pub extern "C" fn auth_drop(user: *mut Author) {
 /// Channel app instance.
 #[no_mangle]
 pub unsafe extern "C" fn auth_channel_address(user: *const Author) -> *const ChannelAddress {
-    unsafe {
-        user.as_ref().map_or(null(), |user| {
-            user.channel_address()
-                .map_or(null(), |channel_address| channel_address as *const ChannelAddress)
-        })
-    }
+    user.as_ref().map_or(null(), |user| {
+        user.channel_address()
+            .map_or(null(), |channel_address| channel_address as *const ChannelAddress)
+    })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn auth_is_multi_branching(user: *const Author) -> uint8_t {
-    unsafe {
-        user.as_ref()
-            .map_or(0, |user| if user.is_multi_branching() { 1 } else { 0 })
-    }
+    user.as_ref()
+        .map_or(0, |user| if user.is_multi_branching() { 1 } else { 0 })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn auth_get_public_key(user: *const Author) -> *const PublicKey {
-    unsafe { user.as_ref().map_or(null(), |user| user.get_pk() as *const PublicKey) }
+    user.as_ref().map_or(null(), |user| user.get_pk() as *const PublicKey)
 }
 
 /// Announce creation of a new Channel.
 #[no_mangle]
 pub unsafe extern "C" fn auth_send_announce(user: *mut Author) -> *const Address {
-    unsafe {
-        user.as_mut().map_or(null(), |user| {
-            user.send_announce().map_or(null(), |a| safe_into_ptr(a))
-        })
-    }
+    user.as_mut().map_or(null(), |user| {
+        user.send_announce().map_or(null(), safe_into_ptr)
+    })
 }
 
 /// unwrap and add a subscriber to the list of subscribers
 #[no_mangle]
 pub unsafe extern "C" fn auth_receive_subscribe(user: *mut Author, link: *const Address) -> Err {
-    unsafe {
-        user.as_mut().map_or(Err::NullArgument, |user| {
-            link.as_ref().map_or(Err::NullArgument, |link| {
-                user.receive_subscribe(link).map_or(Err::OperationFailed, |_| Err::Ok)
-            })
+    user.as_mut().map_or(Err::NullArgument, |user| {
+        link.as_ref().map_or(Err::NullArgument, |link| {
+            user.receive_subscribe(link).map_or(Err::OperationFailed, |_| Err::Ok)
         })
-    }
+    })
 }
 
 /// Create a new keyload for a list of subscribers.
@@ -134,41 +120,37 @@ pub unsafe extern "C" fn auth_send_keyload(
     psk_ids: *const PskIds,
     ke_pks: *const KePks,
 ) -> Err {
-    unsafe {
-        r.as_mut().map_or(Err::NullArgument, |r| {
-            user.as_mut().map_or(Err::NullArgument, |user| {
-                link_to.as_ref().map_or(Err::NullArgument, |link_to| {
-                    psk_ids.as_ref().map_or(Err::NullArgument, |psk_ids| {
-                        ke_pks.as_ref().map_or(Err::NullArgument, |ke_pks| {
-                            user.send_keyload(link_to, psk_ids, ke_pks)
-                                .map_or(Err::OperationFailed, |response| {
-                                    *r = response.into();
-                                    Err::Ok
-                                })
-                        })
+    r.as_mut().map_or(Err::NullArgument, |r| {
+        user.as_mut().map_or(Err::NullArgument, |user| {
+            link_to.as_ref().map_or(Err::NullArgument, |link_to| {
+                psk_ids.as_ref().map_or(Err::NullArgument, |psk_ids| {
+                    ke_pks.as_ref().map_or(Err::NullArgument, |ke_pks| {
+                        user.send_keyload(link_to, psk_ids, ke_pks)
+                            .map_or(Err::OperationFailed, |response| {
+                                *r = response.into();
+                                Err::Ok
+                            })
                     })
                 })
             })
         })
-    }
+    })
 }
 
 /// Create keyload for all subscribed subscribers.
 #[no_mangle]
 pub unsafe extern "C" fn auth_send_keyload_for_everyone(r: *mut MessageLinks, user: *mut Author, link_to: *const Address) -> Err {
-    unsafe {
-        r.as_mut().map_or(Err::NullArgument, |r| {
-            user.as_mut().map_or(Err::NullArgument, |user| {
-                link_to.as_ref().map_or(Err::NullArgument, |link_to| {
-                    user.send_keyload_for_everyone(link_to)
-                        .map_or(Err::OperationFailed, |response| {
-                            *r = response.into();
-                            Err::Ok
-                        })
-                })
+    r.as_mut().map_or(Err::NullArgument, |r| {
+        user.as_mut().map_or(Err::NullArgument, |user| {
+            link_to.as_ref().map_or(Err::NullArgument, |link_to| {
+                user.send_keyload_for_everyone(link_to)
+                    .map_or(Err::OperationFailed, |response| {
+                        *r = response.into();
+                        Err::Ok
+                    })
             })
         })
-    }
+    })
 }
 
 /// Process a Tagged packet message
@@ -182,54 +164,50 @@ pub unsafe extern "C" fn auth_send_tagged_packet(
     masked_payload_ptr: *const uint8_t,
     masked_payload_size: size_t,
 ) -> Err {
-    unsafe {
-        r.as_mut().map_or(Err::NullArgument, |r| {
-            user.as_mut().map_or(Err::NullArgument, |user| {
-                link_to
-                    .into_seq_link(user.is_multi_branching())
-                    .map_or(Err::NullArgument, |link_to| {
-                        let public_payload = Bytes(Vec::from_raw_parts(
-                            public_payload_ptr as *mut u8,
-                            public_payload_size,
-                            public_payload_size,
-                        ));
-                        let masked_payload = Bytes(Vec::from_raw_parts(
-                            masked_payload_ptr as *mut u8,
-                            masked_payload_size,
-                            masked_payload_size,
-                        ));
-                        let e = user
-                            .send_tagged_packet(link_to, &public_payload, &masked_payload)
-                            .map_or(Err::OperationFailed, |response| {
-                                *r = response.into();
-                                Err::Ok
-                            });
-                        let _ = core::mem::ManuallyDrop::new(public_payload.0);
-                        let _ = core::mem::ManuallyDrop::new(masked_payload.0);
-                        e
-                    })
-            })
+    r.as_mut().map_or(Err::NullArgument, |r| {
+        user.as_mut().map_or(Err::NullArgument, |user| {
+            link_to
+                .into_seq_link(user.is_multi_branching())
+                .map_or(Err::NullArgument, |link_to| {
+                    let public_payload = Bytes(Vec::from_raw_parts(
+                        public_payload_ptr as *mut u8,
+                        public_payload_size,
+                        public_payload_size,
+                    ));
+                    let masked_payload = Bytes(Vec::from_raw_parts(
+                        masked_payload_ptr as *mut u8,
+                        masked_payload_size,
+                        masked_payload_size,
+                    ));
+                    let e = user
+                        .send_tagged_packet(link_to, &public_payload, &masked_payload)
+                        .map_or(Err::OperationFailed, |response| {
+                            *r = response.into();
+                            Err::Ok
+                        });
+                    let _ = core::mem::ManuallyDrop::new(public_payload.0);
+                    let _ = core::mem::ManuallyDrop::new(masked_payload.0);
+                    e
+                })
         })
-    }
+    })
 }
 
 /// Process a Tagged packet message
 #[no_mangle]
 pub unsafe extern "C" fn auth_receive_tagged_packet(r: *mut PacketPayloads, user: *mut Author, link: *const Address) -> Err {
-    unsafe {
-        r.as_mut().map_or(Err::NullArgument, |r| {
-            user.as_mut().map_or(Err::NullArgument, |user| {
-                link.as_ref().map_or(Err::NullArgument, |link| {
-                    user
-                        .receive_tagged_packet(link)
-                        .map_or(Err::OperationFailed, |tagged_payloads| {
-                            *r = tagged_payloads.into();
-                            Err::Ok
-                        })
-                })
+    r.as_mut().map_or(Err::NullArgument, |r| {
+        user.as_mut().map_or(Err::NullArgument, |user| {
+            link.as_ref().map_or(Err::NullArgument, |link| {
+                user
+                    .receive_tagged_packet(link)
+                    .map_or(Err::OperationFailed, |tagged_payloads| {
+                        *r = tagged_payloads.into();
+                        Err::Ok
+                    })
             })
         })
-    }
+    })
 }
 
 /// Process a Signed packet message
@@ -243,145 +221,127 @@ pub unsafe extern "C" fn auth_send_signed_packet(
     masked_payload_ptr: *const uint8_t,
     masked_payload_size: size_t,
 ) -> Err {
-    unsafe {
-        r.as_mut().map_or(Err::NullArgument, |r| {
-            user.as_mut().map_or(Err::NullArgument, |user| {
-                link_to
-                    .into_seq_link(user.is_multi_branching())
-                    .map_or(Err::NullArgument, |link_to| {
-                        let public_payload = Bytes(Vec::from_raw_parts(
-                            public_payload_ptr as *mut u8,
-                            public_payload_size,
-                            public_payload_size,
-                        ));
-                        let masked_payload = Bytes(Vec::from_raw_parts(
-                            masked_payload_ptr as *mut u8,
-                            masked_payload_size,
-                            masked_payload_size,
-                        ));
-                        let e = user
-                            .send_signed_packet(link_to, &public_payload, &masked_payload)
-                            .map_or(Err::OperationFailed, |response| {
-                                *r = response.into();
-                                Err::Ok
-                            });
-                        let _ = core::mem::ManuallyDrop::new(public_payload.0);
-                        let _ = core::mem::ManuallyDrop::new(masked_payload.0);
-                        e
-                    })
-            })
+    r.as_mut().map_or(Err::NullArgument, |r| {
+        user.as_mut().map_or(Err::NullArgument, |user| {
+            link_to
+                .into_seq_link(user.is_multi_branching())
+                .map_or(Err::NullArgument, |link_to| {
+                    let public_payload = Bytes(Vec::from_raw_parts(
+                        public_payload_ptr as *mut u8,
+                        public_payload_size,
+                        public_payload_size,
+                    ));
+                    let masked_payload = Bytes(Vec::from_raw_parts(
+                        masked_payload_ptr as *mut u8,
+                        masked_payload_size,
+                        masked_payload_size,
+                    ));
+                    let e = user
+                        .send_signed_packet(link_to, &public_payload, &masked_payload)
+                        .map_or(Err::OperationFailed, |response| {
+                            *r = response.into();
+                            Err::Ok
+                        });
+                    let _ = core::mem::ManuallyDrop::new(public_payload.0);
+                    let _ = core::mem::ManuallyDrop::new(masked_payload.0);
+                    e
+                })
         })
-    }
+    })
 }
 
 /// Process a Signed packet message
 #[no_mangle]
 pub unsafe extern "C" fn auth_receive_signed_packet(r: *mut PacketPayloads, user: *mut Author, link: *const Address) -> Err {
-    unsafe {
-        r.as_mut().map_or(Err::NullArgument, |r| {
-            user.as_mut().map_or(Err::NullArgument, |user| {
-                link.as_ref().map_or(Err::NullArgument, |link| {
-                    user
-                        .receive_signed_packet(link)
-                        .map_or(Err::OperationFailed, |signed_payloads| {
-                            *r = signed_payloads.into();
-                            Err::Ok
-                        })
-                })
+    r.as_mut().map_or(Err::NullArgument, |r| {
+        user.as_mut().map_or(Err::NullArgument, |user| {
+            link.as_ref().map_or(Err::NullArgument, |link| {
+                user
+                    .receive_signed_packet(link)
+                    .map_or(Err::OperationFailed, |signed_payloads| {
+                        *r = signed_payloads.into();
+                        Err::Ok
+                    })
             })
         })
-    }
+    })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn auth_receive_sequence(r: *mut *const Address, user: *mut Author, link: *const Address) -> Err {
-    unsafe {
-        r.as_mut().map_or(Err::NullArgument, |r| {
-            user.as_mut().map_or(Err::NullArgument, |user| {
-                link.as_ref().map_or(Err::NullArgument, |link| {
-                    user.receive_sequence(link).map_or(Err::OperationFailed, |seq_link| {
-                        *r = safe_into_ptr(seq_link);
-                        Err::Ok
-                    })
+    r.as_mut().map_or(Err::NullArgument, |r| {
+        user.as_mut().map_or(Err::NullArgument, |user| {
+            link.as_ref().map_or(Err::NullArgument, |link| {
+                user.receive_sequence(link).map_or(Err::OperationFailed, |seq_link| {
+                    *r = safe_into_ptr(seq_link);
+                    Err::Ok
                 })
             })
         })
-    }
+    })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn auth_gen_next_msg_ids(user: *mut Author) -> *const NextMsgIds {
-    unsafe {
-        user.as_mut().map_or(null(), |user| {
-            let next_msg_ids = user.gen_next_msg_ids(user.is_multi_branching());
-            safe_into_ptr(next_msg_ids)
-        })
-    }
+    user.as_mut().map_or(null(), |user| {
+        let next_msg_ids = user.gen_next_msg_ids(user.is_multi_branching());
+        safe_into_ptr(next_msg_ids)
+    })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn auth_receive_msg(r: *mut *const UnwrappedMessage, user: *mut Author, link: *const Address) -> Err {
-    unsafe {
-        r.as_mut().map_or(Err::NullArgument, |r| {
-            user.as_mut().map_or(Err::NullArgument, |user| {
-                link.as_ref().map_or(Err::NullArgument, |link| {
-                    user.receive_msg(link).map_or(Err::OperationFailed, |u| {
-                        *r = safe_into_ptr(u);
-                        Err::Ok
-                    })
+    r.as_mut().map_or(Err::NullArgument, |r| {
+        user.as_mut().map_or(Err::NullArgument, |user| {
+            link.as_ref().map_or(Err::NullArgument, |link| {
+                user.receive_msg(link).map_or(Err::OperationFailed, |u| {
+                    *r = safe_into_ptr(u);
+                    Err::Ok
                 })
             })
         })
-    }
+    })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn auth_fetch_next_msgs(user: *mut Author) -> *const UnwrappedMessages {
-    unsafe {
-        user.as_mut().map_or(null(), |user| {
-            let m = user.fetch_next_msgs();
-            safe_into_ptr(m)
-        })
-    }
+    user.as_mut().map_or(null(), |user| {
+        let m = user.fetch_next_msgs();
+        safe_into_ptr(m)
+    })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn auth_sync_state(user: *mut Author) -> *const UnwrappedMessages {
-    unsafe {
-        user.as_mut().map_or(null(), |user| {
-            let mut ms = Vec::new();
-            loop {
-                let m = user.fetch_next_msgs();
-                if m.is_empty() {
-                    break;
-                }
-                ms.extend(m);
+    user.as_mut().map_or(null(), |user| {
+        let mut ms = Vec::new();
+        loop {
+            let m = user.fetch_next_msgs();
+            if m.is_empty() {
+                break;
             }
-            safe_into_ptr(ms)
-        })
-    }
+            ms.extend(m);
+        }
+        safe_into_ptr(ms)
+    })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn auth_fetch_state(user: *mut Author) -> *const UserState {
-    unsafe {
-        user.as_mut().map_or(null(), |user| {
-            user.fetch_state().map_or(null(), |state| {
-                safe_into_ptr(state)
-            })
+    user.as_mut().map_or(null(), |user| {
+        user.fetch_state().map_or(null(), |state| {
+            safe_into_ptr(state)
         })
-    }
+    })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn auth_store_psk(user: *mut Author, psk_seed_str: *const c_char) -> *const PskId {
-    unsafe {
-        let psk_seed = CStr::from_ptr(psk_seed_str).to_str().unwrap();
-        user.as_mut().map_or(null(), |user| {
-            let psk = psk_from_seed(psk_seed.as_ref());
-            let pskid = pskid_from_psk(&psk);
-            user.store_psk(pskid.clone(), psk);
-            safe_into_ptr(pskid)
-        })
-    }
+    let psk_seed = CStr::from_ptr(psk_seed_str).to_str().unwrap();
+    user.as_mut().map_or(null(), |user| {
+        let psk = psk_from_seed(psk_seed.as_ref());
+        let pskid = pskid_from_psk(&psk);
+        user.store_psk(pskid, psk);
+        safe_into_ptr(pskid)
+    })
 }

--- a/bindings/c/src/api/auth.rs
+++ b/bindings/c/src/api/auth.rs
@@ -4,7 +4,7 @@ pub type Author = iota_streams::app_channels::api::tangle::Author<TransportWrap>
 
 /// Generate a new Author Instance
 #[no_mangle]
-pub extern "C" fn auth_new(
+pub unsafe extern "C" fn auth_new(
     c_seed: *const c_char,
     c_encoding: *const c_char,
     payload_length: size_t,
@@ -20,7 +20,7 @@ pub extern "C" fn auth_new(
 
 /// Recover an existing channel from seed and existing announcement message
 #[no_mangle]
-pub extern "C" fn auth_recover(
+pub unsafe extern "C" fn auth_recover(
     c_seed: *const c_char,
     c_ann_address: *const Address,
     multi_branching: uint8_t,
@@ -40,7 +40,7 @@ pub extern "C" fn auth_recover(
 
 /// Import an Author instance from an encrypted binary array
 #[no_mangle]
-pub extern "C" fn auth_import(
+pub unsafe extern "C" fn auth_import(
     buffer: Buffer,
     password: *const c_char,
     transport: *mut TransportWrap,
@@ -61,7 +61,7 @@ pub extern "C" fn auth_import(
 }
 
 #[no_mangle]
-pub extern "C" fn auth_export(
+pub unsafe extern "C" fn auth_export(
     user: *mut Author,
     password: *const c_char
 ) -> Buffer {
@@ -81,7 +81,7 @@ pub extern "C" fn auth_drop(user: *mut Author) {
 
 /// Channel app instance.
 #[no_mangle]
-pub extern "C" fn auth_channel_address(user: *const Author) -> *const ChannelAddress {
+pub unsafe extern "C" fn auth_channel_address(user: *const Author) -> *const ChannelAddress {
     unsafe {
         user.as_ref().map_or(null(), |user| {
             user.channel_address()
@@ -91,7 +91,7 @@ pub extern "C" fn auth_channel_address(user: *const Author) -> *const ChannelAdd
 }
 
 #[no_mangle]
-pub extern "C" fn auth_is_multi_branching(user: *const Author) -> uint8_t {
+pub unsafe extern "C" fn auth_is_multi_branching(user: *const Author) -> uint8_t {
     unsafe {
         user.as_ref()
             .map_or(0, |user| if user.is_multi_branching() { 1 } else { 0 })
@@ -99,13 +99,13 @@ pub extern "C" fn auth_is_multi_branching(user: *const Author) -> uint8_t {
 }
 
 #[no_mangle]
-pub extern "C" fn auth_get_public_key(user: *const Author) -> *const PublicKey {
+pub unsafe extern "C" fn auth_get_public_key(user: *const Author) -> *const PublicKey {
     unsafe { user.as_ref().map_or(null(), |user| user.get_pk() as *const PublicKey) }
 }
 
 /// Announce creation of a new Channel.
 #[no_mangle]
-pub extern "C" fn auth_send_announce(user: *mut Author) -> *const Address {
+pub unsafe extern "C" fn auth_send_announce(user: *mut Author) -> *const Address {
     unsafe {
         user.as_mut().map_or(null(), |user| {
             user.send_announce().map_or(null(), |a| safe_into_ptr(a))
@@ -115,7 +115,7 @@ pub extern "C" fn auth_send_announce(user: *mut Author) -> *const Address {
 
 /// unwrap and add a subscriber to the list of subscribers
 #[no_mangle]
-pub extern "C" fn auth_receive_subscribe(user: *mut Author, link: *const Address) -> Err {
+pub unsafe extern "C" fn auth_receive_subscribe(user: *mut Author, link: *const Address) -> Err {
     unsafe {
         user.as_mut().map_or(Err::NullArgument, |user| {
             link.as_ref().map_or(Err::NullArgument, |link| {
@@ -127,7 +127,7 @@ pub extern "C" fn auth_receive_subscribe(user: *mut Author, link: *const Address
 
 /// Create a new keyload for a list of subscribers.
 #[no_mangle]
-pub extern "C" fn auth_send_keyload(
+pub unsafe extern "C" fn auth_send_keyload(
     r: *mut MessageLinks,
     user: *mut Author,
     link_to: *const Address,
@@ -155,7 +155,7 @@ pub extern "C" fn auth_send_keyload(
 
 /// Create keyload for all subscribed subscribers.
 #[no_mangle]
-pub extern "C" fn auth_send_keyload_for_everyone(r: *mut MessageLinks, user: *mut Author, link_to: *const Address) -> Err {
+pub unsafe extern "C" fn auth_send_keyload_for_everyone(r: *mut MessageLinks, user: *mut Author, link_to: *const Address) -> Err {
     unsafe {
         r.as_mut().map_or(Err::NullArgument, |r| {
             user.as_mut().map_or(Err::NullArgument, |user| {
@@ -173,7 +173,7 @@ pub extern "C" fn auth_send_keyload_for_everyone(r: *mut MessageLinks, user: *mu
 
 /// Process a Tagged packet message
 #[no_mangle]
-pub extern "C" fn auth_send_tagged_packet(
+pub unsafe extern "C" fn auth_send_tagged_packet(
     r: *mut MessageLinks,
     user: *mut Author,
     link_to: MessageLinks,
@@ -215,7 +215,7 @@ pub extern "C" fn auth_send_tagged_packet(
 
 /// Process a Tagged packet message
 #[no_mangle]
-pub extern "C" fn auth_receive_tagged_packet(r: *mut PacketPayloads, user: *mut Author, link: *const Address) -> Err {
+pub unsafe extern "C" fn auth_receive_tagged_packet(r: *mut PacketPayloads, user: *mut Author, link: *const Address) -> Err {
     unsafe {
         r.as_mut().map_or(Err::NullArgument, |r| {
             user.as_mut().map_or(Err::NullArgument, |user| {
@@ -234,7 +234,7 @@ pub extern "C" fn auth_receive_tagged_packet(r: *mut PacketPayloads, user: *mut 
 
 /// Process a Signed packet message
 #[no_mangle]
-pub extern "C" fn auth_send_signed_packet(
+pub unsafe extern "C" fn auth_send_signed_packet(
     r: *mut MessageLinks,
     user: *mut Author,
     link_to: MessageLinks,
@@ -276,7 +276,7 @@ pub extern "C" fn auth_send_signed_packet(
 
 /// Process a Signed packet message
 #[no_mangle]
-pub extern "C" fn auth_receive_signed_packet(r: *mut PacketPayloads, user: *mut Author, link: *const Address) -> Err {
+pub unsafe extern "C" fn auth_receive_signed_packet(r: *mut PacketPayloads, user: *mut Author, link: *const Address) -> Err {
     unsafe {
         r.as_mut().map_or(Err::NullArgument, |r| {
             user.as_mut().map_or(Err::NullArgument, |user| {
@@ -294,7 +294,7 @@ pub extern "C" fn auth_receive_signed_packet(r: *mut PacketPayloads, user: *mut 
 }
 
 #[no_mangle]
-pub extern "C" fn auth_receive_sequence(r: *mut *const Address, user: *mut Author, link: *const Address) -> Err {
+pub unsafe extern "C" fn auth_receive_sequence(r: *mut *const Address, user: *mut Author, link: *const Address) -> Err {
     unsafe {
         r.as_mut().map_or(Err::NullArgument, |r| {
             user.as_mut().map_or(Err::NullArgument, |user| {
@@ -310,7 +310,7 @@ pub extern "C" fn auth_receive_sequence(r: *mut *const Address, user: *mut Autho
 }
 
 #[no_mangle]
-pub extern "C" fn auth_gen_next_msg_ids(user: *mut Author) -> *const NextMsgIds {
+pub unsafe extern "C" fn auth_gen_next_msg_ids(user: *mut Author) -> *const NextMsgIds {
     unsafe {
         user.as_mut().map_or(null(), |user| {
             let next_msg_ids = user.gen_next_msg_ids(user.is_multi_branching());
@@ -320,7 +320,7 @@ pub extern "C" fn auth_gen_next_msg_ids(user: *mut Author) -> *const NextMsgIds 
 }
 
 #[no_mangle]
-pub extern "C" fn auth_receive_msg(r: *mut *const UnwrappedMessage, user: *mut Author, link: *const Address) -> Err {
+pub unsafe extern "C" fn auth_receive_msg(r: *mut *const UnwrappedMessage, user: *mut Author, link: *const Address) -> Err {
     unsafe {
         r.as_mut().map_or(Err::NullArgument, |r| {
             user.as_mut().map_or(Err::NullArgument, |user| {
@@ -336,7 +336,7 @@ pub extern "C" fn auth_receive_msg(r: *mut *const UnwrappedMessage, user: *mut A
 }
 
 #[no_mangle]
-pub extern "C" fn auth_fetch_next_msgs(user: *mut Author) -> *const UnwrappedMessages {
+pub unsafe extern "C" fn auth_fetch_next_msgs(user: *mut Author) -> *const UnwrappedMessages {
     unsafe {
         user.as_mut().map_or(null(), |user| {
             let m = user.fetch_next_msgs();
@@ -346,7 +346,7 @@ pub extern "C" fn auth_fetch_next_msgs(user: *mut Author) -> *const UnwrappedMes
 }
 
 #[no_mangle]
-pub extern "C" fn auth_sync_state(user: *mut Author) -> *const UnwrappedMessages {
+pub unsafe extern "C" fn auth_sync_state(user: *mut Author) -> *const UnwrappedMessages {
     unsafe {
         user.as_mut().map_or(null(), |user| {
             let mut ms = Vec::new();
@@ -363,7 +363,7 @@ pub extern "C" fn auth_sync_state(user: *mut Author) -> *const UnwrappedMessages
 }
 
 #[no_mangle]
-pub extern "C" fn auth_fetch_state(user: *mut Author) -> *const UserState {
+pub unsafe extern "C" fn auth_fetch_state(user: *mut Author) -> *const UserState {
     unsafe {
         user.as_mut().map_or(null(), |user| {
             user.fetch_state().map_or(null(), |state| {
@@ -374,7 +374,7 @@ pub extern "C" fn auth_fetch_state(user: *mut Author) -> *const UserState {
 }
 
 #[no_mangle]
-pub extern "C" fn auth_store_psk(user: *mut Author, psk_seed_str: *const c_char) -> *const PskId {
+pub unsafe extern "C" fn auth_store_psk(user: *mut Author, psk_seed_str: *const c_char) -> *const PskId {
     unsafe {
         let psk_seed = CStr::from_ptr(psk_seed_str).to_str().unwrap();
         user.as_mut().map_or(null(), |user| {

--- a/bindings/c/src/api/mod.rs
+++ b/bindings/c/src/api/mod.rs
@@ -16,7 +16,8 @@ use iota_streams::{
         },
     },
     app_channels::api::{
-        make_psk,
+        psk_from_seed,
+        pskid_from_psk,
         tangle::*
     },
     core::{
@@ -88,10 +89,6 @@ pub extern "C" fn pskid_as_str(pskid: *const PskId) -> *const c_char {
             CString::new(hex::encode(&pskid)).map_or(null(), |id| id.into_raw())
         })
     }
-}
-
-pub(crate) fn psk_from_str(psk: &str) -> *const Psk {
-    hex::decode(psk.to_string()).map_or(null(), |psk| safe_into_ptr(make_psk(&psk)))
 }
 
 pub type NextMsgIds = Vec<(PublicKey, Cursor<Address>)>;

--- a/bindings/c/src/api/mod.rs
+++ b/bindings/c/src/api/mod.rs
@@ -59,14 +59,14 @@ pub enum Err {
 }
 
 #[no_mangle]
-pub extern "C" fn address_from_string(c_addr: *const c_char) -> *const Address {
+pub unsafe extern "C" fn address_from_string(c_addr: *const c_char) -> *const Address {
     unsafe {
         Address::from_c_str(c_addr)
     }
 }
 
 #[no_mangle]
-pub extern "C" fn public_key_to_string(pubkey: *const PublicKey) -> *const c_char {
+pub unsafe extern "C" fn public_key_to_string(pubkey: *const PublicKey) -> *const c_char {
     unsafe {
         pubkey.as_ref().map_or(null(), |pk| {
             CString::new(hex::encode(pk.as_bytes())).map_or(null(), |pk| pk.into_raw())
@@ -75,7 +75,7 @@ pub extern "C" fn public_key_to_string(pubkey: *const PublicKey) -> *const c_cha
 }
 
 #[no_mangle]
-pub extern "C" fn drop_address(addr: *const Address) {
+pub unsafe extern "C" fn drop_address(addr: *const Address) {
     safe_drop_ptr(addr)
 }
 
@@ -83,7 +83,7 @@ pub type PskIds = Vec<PskId>;
 pub type KePks = Vec<PublicKey>;
 
 #[no_mangle]
-pub extern "C" fn pskid_as_str(pskid: *const PskId) -> *const c_char {
+pub unsafe extern "C" fn pskid_as_str(pskid: *const PskId) -> *const c_char {
     unsafe {
         pskid.as_ref().map_or(null(), |pskid| {
             CString::new(hex::encode(&pskid)).map_or(null(), |id| id.into_raw())
@@ -105,7 +105,7 @@ pub extern "C" fn drop_user_state(s: *const UserState) {
 }
 
 #[no_mangle]
-pub extern "C" fn get_link_from_state(state: *const UserState, pub_key: *const PublicKey) -> *const Address {
+pub unsafe extern "C" fn get_link_from_state(state: *const UserState, pub_key: *const PublicKey) -> *const Address {
     unsafe {
         state.as_ref().map_or(null(), |state_ref| {
             pub_key.as_ref().map_or(null(), |pub_key| {
@@ -122,7 +122,7 @@ pub extern "C" fn get_link_from_state(state: *const UserState, pub_key: *const P
 }
 
 #[no_mangle]
-pub extern "C" fn drop_unwrapped_message(ms: *const UnwrappedMessage) {
+pub unsafe extern "C" fn drop_unwrapped_message(ms: *const UnwrappedMessage) {
     unsafe {
         Box::from_raw(ms as *mut UnwrappedMessage);
     }
@@ -152,7 +152,7 @@ pub extern "C" fn transport_drop(tsp: *mut TransportWrap) {
 
 #[cfg(feature = "sync-client")]
 #[no_mangle]
-pub extern "C" fn transport_client_new_from_url(c_url: *const c_char) -> *mut TransportWrap {
+pub unsafe extern "C" fn transport_client_new_from_url(c_url: *const c_char) -> *mut TransportWrap {
     unsafe {
         let url = CStr::from_ptr(c_url).to_str().unwrap();
 
@@ -284,7 +284,7 @@ impl From<MilestoneResponse> for Milestone {
 }
 
 #[no_mangle]
-pub extern "C" fn transport_get_link_details(r: *mut TransportDetails, tsp: *mut TransportWrap, link: *const Address) -> Err {
+pub unsafe extern "C" fn transport_get_link_details(r: *mut TransportDetails, tsp: *mut TransportWrap, link: *const Address) -> Err {
     unsafe {
         r.as_mut().map_or(Err::NullArgument, |r| {
             tsp.as_mut().map_or(Err::NullArgument, |tsp| {
@@ -352,7 +352,7 @@ pub extern "C" fn drop_links(links: MessageLinks) {
 }
 
 #[no_mangle]
-pub extern "C" fn get_msg_link(msg_links: *const MessageLinks) -> *const Address {
+pub unsafe extern "C" fn get_msg_link(msg_links: *const MessageLinks) -> *const Address {
     unsafe {
         msg_links.as_ref().map_or(null(), |links| {
             links.msg_link
@@ -361,7 +361,7 @@ pub extern "C" fn get_msg_link(msg_links: *const MessageLinks) -> *const Address
 }
 
 #[no_mangle]
-pub extern "C" fn get_seq_link(msg_links: *const MessageLinks) -> *const Address {
+pub unsafe extern "C" fn get_seq_link(msg_links: *const MessageLinks) -> *const Address {
     unsafe {
         msg_links.as_ref().map_or(null(), |links| {
             links.seq_link
@@ -494,14 +494,14 @@ pub extern "C" fn drop_payloads(payloads: PacketPayloads) {
 }
 
 #[no_mangle]
-pub extern "C" fn drop_str(string: *const c_char) {
+pub unsafe extern "C" fn drop_str(string: *const c_char) {
     unsafe {
         CString::from_raw(string as *mut c_char);
     }
 }
 
 #[no_mangle]
-pub extern "C" fn get_channel_address_str(appinst: *const ChannelAddress) -> *const c_char {
+pub unsafe extern "C" fn get_channel_address_str(appinst: *const ChannelAddress) -> *const c_char {
     unsafe {
         appinst.as_ref().map_or(null(), |inst| {
             CString::new(hex::encode(inst)).map_or(null(), |inst_str| inst_str.into_raw())
@@ -510,7 +510,7 @@ pub extern "C" fn get_channel_address_str(appinst: *const ChannelAddress) -> *co
 }
 
 #[no_mangle]
-pub extern "C" fn get_msgid_str(msgid: *mut MsgId) -> *const c_char {
+pub unsafe extern "C" fn get_msgid_str(msgid: *mut MsgId) -> *const c_char {
     unsafe {
         msgid.as_ref().map_or(null(), |id| {
             CString::new(hex::encode(id)).map_or(null(), |id_str| id_str.into_raw())
@@ -519,7 +519,7 @@ pub extern "C" fn get_msgid_str(msgid: *mut MsgId) -> *const c_char {
 }
 
 #[no_mangle]
-pub extern "C" fn get_address_inst_str(address: *mut Address) -> *mut c_char {
+pub unsafe extern "C" fn get_address_inst_str(address: *mut Address) -> *mut c_char {
     unsafe {
         address.as_ref().map_or(null_mut(), |addr| {
             CString::new(hex::encode(addr.appinst.as_ref())).map_or(null_mut(), |inst| inst.into_raw())
@@ -528,7 +528,7 @@ pub extern "C" fn get_address_inst_str(address: *mut Address) -> *mut c_char {
 }
 
 #[no_mangle]
-pub extern "C" fn get_address_id_str(address: *mut Address) -> *mut c_char {
+pub unsafe extern "C" fn get_address_id_str(address: *mut Address) -> *mut c_char {
     unsafe {
         address.as_ref().map_or(null_mut(), |addr| {
             CString::new(hex::encode(addr.msgid.as_ref())).map_or(null_mut(), |id| id.into_raw())
@@ -537,7 +537,7 @@ pub extern "C" fn get_address_id_str(address: *mut Address) -> *mut c_char {
 }
 
 #[no_mangle]
-pub extern "C" fn get_address_index_str(address: *mut Address) -> *mut c_char {
+pub unsafe extern "C" fn get_address_index_str(address: *mut Address) -> *mut c_char {
     unsafe {
         address.as_ref().map_or(null_mut(), |addr| {
             get_hash(addr.appinst.as_ref(), addr.msgid.as_ref())
@@ -551,17 +551,17 @@ pub extern "C" fn get_address_index_str(address: *mut Address) -> *mut c_char {
 }
 
 #[no_mangle]
-pub extern "C" fn get_payload(msg: *const UnwrappedMessage) -> PacketPayloads {
+pub unsafe extern "C" fn get_payload(msg: *const UnwrappedMessage) -> PacketPayloads {
     unsafe { msg.as_ref().map_or(PacketPayloads::default(), handle_message_contents) }
 }
 
 #[no_mangle]
-pub extern "C" fn get_payloads_count(msgs: *const UnwrappedMessages) -> usize {
+pub unsafe extern "C" fn get_payloads_count(msgs: *const UnwrappedMessages) -> usize {
     unsafe { msgs.as_ref().map_or(0, |msgs| msgs.len()) }
 }
 
 #[no_mangle]
-pub extern "C" fn get_indexed_payload(msgs: *const UnwrappedMessages, index: size_t) -> PacketPayloads {
+pub unsafe extern "C" fn get_indexed_payload(msgs: *const UnwrappedMessages, index: size_t) -> PacketPayloads {
     unsafe {
         msgs.as_ref()
             .map_or(PacketPayloads::default(), |msgs| handle_message_contents(&msgs[index]))

--- a/bindings/c/src/api/mod.rs
+++ b/bindings/c/src/api/mod.rs
@@ -15,10 +15,16 @@ use iota_streams::{
             get_hash,
         },
     },
-    app_channels::api::tangle::*,
+    app_channels::api::{
+        make_psk,
+        tangle::*
+    },
     core::{
         prelude::*,
-        psk,
+        psk::{
+            PskId,
+            Psk,
+        },
     },
 };
 
@@ -72,8 +78,21 @@ pub extern "C" fn drop_address(addr: *const Address) {
     safe_drop_ptr(addr)
 }
 
-pub type PskIds = psk::PskIds;
+pub type PskIds = Vec<PskId>;
 pub type KePks = Vec<PublicKey>;
+
+#[no_mangle]
+pub extern "C" fn pskid_as_str(pskid: *const PskId) -> *const c_char {
+    unsafe {
+        pskid.as_ref().map_or(null(), |pskid| {
+            CString::new(hex::encode(&pskid)).map_or(null(), |id| id.into_raw())
+        })
+    }
+}
+
+pub(crate) fn psk_from_str(psk: &str) -> *const Psk {
+    hex::decode(psk.to_string()).map_or(null(), |psk| safe_into_ptr(make_psk(&psk)))
+}
 
 pub type NextMsgIds = Vec<(PublicKey, Cursor<Address>)>;
 

--- a/bindings/c/src/api/sub.rs
+++ b/bindings/c/src/api/sub.rs
@@ -10,9 +10,9 @@ pub unsafe extern "C" fn sub_new(
     payload_length: size_t,
     transport: *mut TransportWrap,
 ) -> *mut Subscriber {
-    let seed = unsafe { CStr::from_ptr(c_seed).to_str().unwrap() };
-    let encoding = unsafe { CStr::from_ptr(c_encoding).to_str().unwrap() };
-    let tsp = unsafe { (*transport).clone() };
+    let seed = CStr::from_ptr(c_seed).to_str().unwrap();
+    let encoding = CStr::from_ptr(c_encoding).to_str().unwrap();
+    let tsp = (*transport).clone();
     let subscriber = Subscriber::new(seed, encoding, payload_length, tsp);
     safe_into_mut_ptr(subscriber)
 }
@@ -24,16 +24,14 @@ pub unsafe extern "C" fn sub_recover(
     c_ann_address: *const Address,
     transport: *mut TransportWrap
 ) -> *mut Subscriber {
-    unsafe {
-        c_ann_address.as_ref().map_or(null_mut(), |addr| {
-            let seed = CStr::from_ptr(c_seed).to_str().unwrap();
-            let tsp = (*transport).clone();
-            Subscriber::recover(seed, addr, tsp)
-                .map_or(null_mut(), |sub| {
-                    safe_into_mut_ptr(sub)
-                })
-        })
-    }
+    c_ann_address.as_ref().map_or(null_mut(), |addr| {
+        let seed = CStr::from_ptr(c_seed).to_str().unwrap();
+        let tsp = (*transport).clone();
+        Subscriber::recover(seed, addr, tsp)
+            .map_or(null_mut(), |sub| {
+                safe_into_mut_ptr(sub)
+            })
+    })
 }
 
 /// Import an Author instance from an encrypted binary array
@@ -43,19 +41,17 @@ pub unsafe extern "C" fn sub_import(
     password: *const c_char,
     transport: *mut TransportWrap,
 ) -> *mut Subscriber {
-    unsafe {
-        let bytes_vec = Vec::from_raw_parts(
-            buffer.ptr as *mut u8,
-            buffer.size,
-            buffer.cap,
-        );
-        let password_str = CStr::from_ptr(password).to_str().unwrap();
-        let tsp = (*transport).clone();
-        Subscriber::import(&bytes_vec, password_str, tsp)
-            .map_or(null_mut(), |sub| {
-                Box::into_raw(Box::new(sub))
-        })
-    }
+    let bytes_vec = Vec::from_raw_parts(
+        buffer.ptr as *mut u8,
+        buffer.size,
+        buffer.cap,
+    );
+    let password_str = CStr::from_ptr(password).to_str().unwrap();
+    let tsp = (*transport).clone();
+    Subscriber::import(&bytes_vec, password_str, tsp)
+        .map_or(null_mut(), |sub| {
+            Box::into_raw(Box::new(sub))
+    })
 }
 
 #[no_mangle]
@@ -63,13 +59,11 @@ pub unsafe extern "C" fn sub_export(
     user: *mut Subscriber,
     password: *const c_char
 ) -> Buffer {
-    unsafe {
-        let password_str = CStr::from_ptr(password).to_str().unwrap();
-        user.as_ref().map_or(Buffer::default(), |user| {
-            let bytes = user.export(password_str).unwrap();
-            bytes.into()
-        })
-    }
+    let password_str = CStr::from_ptr(password).to_str().unwrap();
+    user.as_ref().map_or(Buffer::default(), |user| {
+        let bytes = user.export(password_str).unwrap();
+        bytes.into()
+    })
 }
 
 #[no_mangle]
@@ -80,80 +74,66 @@ pub extern "C" fn sub_drop(user: *mut Subscriber) {
 /// Channel app instance.
 #[no_mangle]
 pub unsafe extern "C" fn sub_channel_address(user: *const Subscriber) -> *const ChannelAddress {
-    unsafe {
-        user.as_ref().map_or(null(), |user| {
-            user.channel_address().map_or(null(), |channel_address| {
-                channel_address as *const ChannelAddress
-            })
+    user.as_ref().map_or(null(), |user| {
+        user.channel_address().map_or(null(), |channel_address| {
+            channel_address as *const ChannelAddress
         })
-    }
+    })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn sub_is_multi_branching(user: *const Subscriber) -> uint8_t {
-    unsafe {
-        user.as_ref().map_or(0, |user| {
-            if user.is_multi_branching() { 1 } else { 0 }
-        })
-    }
+    user.as_ref().map_or(0, |user| {
+        if user.is_multi_branching() { 1 } else { 0 }
+    })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn sub_get_public_key(user: *const Subscriber) -> *const PublicKey {
-    unsafe {
-        user.as_ref().map_or(null(), |user| {
-            user.get_pk() as *const PublicKey
-        })
-    }
+    user.as_ref().map_or(null(), |user| {
+        user.get_pk() as *const PublicKey
+    })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn sub_is_registered(user: *const Subscriber) -> u8 {
-    unsafe {
-        user.as_ref().map_or(0, |user| {
-            if user.is_registered() { 1 } else { 0 }
-        })
-    }
+    user.as_ref().map_or(0, |user| {
+        if user.is_registered() { 1 } else { 0 }
+    })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn sub_unregister(user: *mut Subscriber) {
-    unsafe {
-        user.as_mut().map_or((), |user| {
-            user.unregister();
-        })
-    }
+    user.as_mut().map_or((), |user| {
+        user.unregister();
+    })
 }
 
 /// Handle Channel app instance announcement.
 #[no_mangle]
 pub unsafe extern "C" fn sub_receive_announce(user: *mut Subscriber, link: *const Address) -> Err {
-    unsafe {
-        user.as_mut().map_or(Err::NullArgument, |user| {
-            link.as_ref().map_or(Err::NullArgument, |link| {
-                user.receive_announcement(link).map_or(Err::OperationFailed, |_| Err::Ok)
-            })
+    user.as_mut().map_or(Err::NullArgument, |user| {
+        link.as_ref().map_or(Err::NullArgument, |link| {
+            user.receive_announcement(link).map_or(Err::OperationFailed, |_| Err::Ok)
         })
-    }
+    })
 }
 
 /// Subscribe to a Channel app instance.
 #[no_mangle]
 pub unsafe extern "C" fn sub_send_subscribe(r: *mut *const Address, user: *mut Subscriber, announcement_link: *const Address) -> Err {
-    unsafe {
-        r.as_mut().map_or(Err::NullArgument, |r| {
-            user.as_mut().map_or(Err::NullArgument, |user| {
-                announcement_link.as_ref().map_or(Err::NullArgument, |announcement_link| -> Err {
-                    user
-                        .send_subscribe(announcement_link)
-                        .map_or(Err::OperationFailed, |link| -> Err {
-                            *r = safe_into_ptr(link);
-                            Err::Ok
-                        })
-                })
+    r.as_mut().map_or(Err::NullArgument, |r| {
+        user.as_mut().map_or(Err::NullArgument, |user| {
+            announcement_link.as_ref().map_or(Err::NullArgument, |announcement_link| -> Err {
+                user
+                    .send_subscribe(announcement_link)
+                    .map_or(Err::OperationFailed, |link| -> Err {
+                        *r = safe_into_ptr(link);
+                        Err::Ok
+                    })
             })
         })
-    }
+    })
 }
 
 #[no_mangle]
@@ -166,35 +146,33 @@ pub unsafe extern "C" fn sub_send_tagged_packet(
     masked_payload_ptr: *const uint8_t,
     masked_payload_size: size_t,
 ) -> Err {
-    unsafe {
-        r.as_mut().map_or(Err::NullArgument, |r| {
-            user.as_mut().map_or(Err::NullArgument, |user| {
-                link_to
-                    .into_seq_link(user.is_multi_branching())
-                    .map_or(Err::NullArgument, |link_to| {
-                        let public_payload = Bytes(Vec::from_raw_parts(
-                            public_payload_ptr as *mut u8,
-                            public_payload_size,
-                            public_payload_size,
-                        ));
-                        let masked_payload = Bytes(Vec::from_raw_parts(
-                            masked_payload_ptr as *mut u8,
-                            masked_payload_size,
-                            masked_payload_size,
-                        ));
-                        let e = user
-                            .send_tagged_packet(link_to, &public_payload, &masked_payload)
-                            .map_or(Err::OperationFailed, |response| {
-                                *r = response.into();
-                                Err::Ok
-                            });
-                        let _ = core::mem::ManuallyDrop::new(public_payload.0);
-                        let _ = core::mem::ManuallyDrop::new(masked_payload.0);
-                        e
-                    })
-            })
+    r.as_mut().map_or(Err::NullArgument, |r| {
+        user.as_mut().map_or(Err::NullArgument, |user| {
+            link_to
+                .into_seq_link(user.is_multi_branching())
+                .map_or(Err::NullArgument, |link_to| {
+                    let public_payload = Bytes(Vec::from_raw_parts(
+                        public_payload_ptr as *mut u8,
+                        public_payload_size,
+                        public_payload_size,
+                    ));
+                    let masked_payload = Bytes(Vec::from_raw_parts(
+                        masked_payload_ptr as *mut u8,
+                        masked_payload_size,
+                        masked_payload_size,
+                    ));
+                    let e = user
+                        .send_tagged_packet(link_to, &public_payload, &masked_payload)
+                        .map_or(Err::OperationFailed, |response| {
+                            *r = response.into();
+                            Err::Ok
+                        });
+                    let _ = core::mem::ManuallyDrop::new(public_payload.0);
+                    let _ = core::mem::ManuallyDrop::new(masked_payload.0);
+                    e
+                })
         })
-    }
+    })
 }
 
 #[no_mangle]
@@ -207,210 +185,186 @@ pub unsafe extern "C" fn sub_send_signed_packet(
     masked_payload_ptr: *const uint8_t,
     masked_payload_size: size_t,
 ) -> Err {
-    unsafe {
-        r.as_mut().map_or(Err::NullArgument, |r| {
-            user.as_mut().map_or(Err::NullArgument, |user| {
-                link_to
-                    .into_seq_link(user.is_multi_branching())
-                    .map_or(Err::NullArgument, |link_to| {
-                        let public_payload = Bytes(Vec::from_raw_parts(
-                            public_payload_ptr as *mut u8,
-                            public_payload_size,
-                            public_payload_size,
-                        ));
-                        let masked_payload = Bytes(Vec::from_raw_parts(
-                            masked_payload_ptr as *mut u8,
-                            masked_payload_size,
-                            masked_payload_size,
-                        ));
-                        let e = user
-                            .send_signed_packet(link_to, &public_payload, &masked_payload)
-                            .map_or(Err::OperationFailed, |response| {
-                                *r = response.into();
-                                Err::Ok
-                            });
-                        let _ = core::mem::ManuallyDrop::new(public_payload.0);
-                        let _ = core::mem::ManuallyDrop::new(masked_payload.0);
-                        e
-                    })
-            })
+    r.as_mut().map_or(Err::NullArgument, |r| {
+        user.as_mut().map_or(Err::NullArgument, |user| {
+            link_to
+                .into_seq_link(user.is_multi_branching())
+                .map_or(Err::NullArgument, |link_to| {
+                    let public_payload = Bytes(Vec::from_raw_parts(
+                        public_payload_ptr as *mut u8,
+                        public_payload_size,
+                        public_payload_size,
+                    ));
+                    let masked_payload = Bytes(Vec::from_raw_parts(
+                        masked_payload_ptr as *mut u8,
+                        masked_payload_size,
+                        masked_payload_size,
+                    ));
+                    let e = user
+                        .send_signed_packet(link_to, &public_payload, &masked_payload)
+                        .map_or(Err::OperationFailed, |response| {
+                            *r = response.into();
+                            Err::Ok
+                        });
+                    let _ = core::mem::ManuallyDrop::new(public_payload.0);
+                    let _ = core::mem::ManuallyDrop::new(masked_payload.0);
+                    e
+                })
         })
-    }
+    })
 }
 
 
 /// Process a keyload message
 #[no_mangle]
 pub unsafe extern "C" fn sub_receive_keyload(user: *mut Subscriber, link: *const Address) -> Err {
-    unsafe {
-        user.as_mut().map_or(Err::NullArgument, |user| {
-            link.as_ref().map_or(Err::NullArgument, |link| {
-                user.receive_keyload(link)
-                    .map_or(Err::OperationFailed, |_| Err::Ok)
-            })
+    user.as_mut().map_or(Err::NullArgument, |user| {
+        link.as_ref().map_or(Err::NullArgument, |link| {
+            user.receive_keyload(link)
+                .map_or(Err::OperationFailed, |_| Err::Ok)
         })
-    }
+    })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn sub_receive_sequence(r: *mut *const Address, user: *mut Subscriber, link: *const Address) -> Err {
-    unsafe {
-        r.as_mut().map_or(Err::NullArgument, |r| {
-            user.as_mut().map_or(Err::NullArgument, |user| {
-                link.as_ref().map_or(Err::NullArgument, |link| {
-                    user.receive_sequence(link).map_or(Err::OperationFailed, |seq_link| {
-                        *r = safe_into_ptr(seq_link);
-                        Err::Ok
-                    })
+    r.as_mut().map_or(Err::NullArgument, |r| {
+        user.as_mut().map_or(Err::NullArgument, |user| {
+            link.as_ref().map_or(Err::NullArgument, |link| {
+                user.receive_sequence(link).map_or(Err::OperationFailed, |seq_link| {
+                    *r = safe_into_ptr(seq_link);
+                    Err::Ok
                 })
             })
         })
-    }
+    })
 }
 
 /// Process a Tagged packet message
 #[no_mangle]
 pub unsafe extern "C" fn sub_receive_tagged_packet(r: *mut PacketPayloads, user: *mut Subscriber, link: *const Address) -> Err {
-    unsafe {
-        r.as_mut().map_or(Err::NullArgument, |r| {
-            user.as_mut().map_or(Err::NullArgument, |user| {
-                link.as_ref().map_or(Err::NullArgument, |link| {
-                    user.receive_tagged_packet(link)
-                        .map_or(Err::OperationFailed, |tagged_payloads| {
-                            *r = tagged_payloads.into();
-                            Err::Ok
-                        })
-                })
+    r.as_mut().map_or(Err::NullArgument, |r| {
+        user.as_mut().map_or(Err::NullArgument, |user| {
+            link.as_ref().map_or(Err::NullArgument, |link| {
+                user.receive_tagged_packet(link)
+                    .map_or(Err::OperationFailed, |tagged_payloads| {
+                        *r = tagged_payloads.into();
+                        Err::Ok
+                    })
             })
         })
-    }
+    })
 }
 
 /// Process a Signed packet message
 #[no_mangle]
 pub unsafe extern "C" fn sub_receive_signed_packet(r: *mut PacketPayloads, user: *mut Subscriber, link: *const Address) -> Err {
-    unsafe {
-        r.as_mut().map_or(Err::NullArgument, |r| {
-            user.as_mut().map_or(Err::NullArgument, |user| {
-                link.as_ref().map_or(Err::NullArgument, |link| {
-                    user.receive_signed_packet(link)
-                        .map_or(Err::OperationFailed, |signed_payloads| {
-                            *r = signed_payloads.into();
-                            Err::Ok
-                        })
-                })
+    r.as_mut().map_or(Err::NullArgument, |r| {
+        user.as_mut().map_or(Err::NullArgument, |user| {
+            link.as_ref().map_or(Err::NullArgument, |link| {
+                user.receive_signed_packet(link)
+                    .map_or(Err::OperationFailed, |signed_payloads| {
+                        *r = signed_payloads.into();
+                        Err::Ok
+                    })
             })
         })
-    }
+    })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn sub_gen_next_msg_ids(user: *mut Subscriber) -> *const NextMsgIds {
-    unsafe {
-        user.as_mut().map_or(null(), |user| {
-            let next_msg_ids = user.gen_next_msg_ids(user.is_multi_branching());
-            safe_into_ptr(next_msg_ids)
-        })
-    }
+    user.as_mut().map_or(null(), |user| {
+        let next_msg_ids = user.gen_next_msg_ids(user.is_multi_branching());
+        safe_into_ptr(next_msg_ids)
+    })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn sub_receive_keyload_from_ids(r: *mut MessageLinks, user: *mut Subscriber, next_msg_ids: *const NextMsgIds) -> Err {
-    unsafe {
-        r.as_mut().map_or(Err::NullArgument, |r| {
-            user.as_mut().map_or(Err::NullArgument, |user| {
-                next_msg_ids.as_ref().map_or(Err::NullArgument, |ids| {
-                    for (_pk, cursor) in ids {
-                        let keyload_link = user.receive_sequence(&cursor.link);
-                        if keyload_link.is_ok() {
-                            let keyload_link = keyload_link.unwrap();
-                            match user.receive_keyload(&keyload_link) {
-                                Ok(true) => {
-                                    *r = (cursor.link.clone(), Some(keyload_link)).into();
-                                    return Err::Ok;
-                                },
-                                Ok(false) => {},
-                                Err(_) => return Err::OperationFailed,
-                            }
+    r.as_mut().map_or(Err::NullArgument, |r| {
+        user.as_mut().map_or(Err::NullArgument, |user| {
+            next_msg_ids.as_ref().map_or(Err::NullArgument, |ids| {
+                for (_pk, cursor) in ids {
+                    let keyload_link = user.receive_sequence(&cursor.link);
+                    if keyload_link.is_ok() {
+                        let keyload_link = keyload_link.unwrap();
+                        match user.receive_keyload(&keyload_link) {
+                            Ok(true) => {
+                                *r = (cursor.link.clone(), Some(keyload_link)).into();
+                                return Err::Ok;
+                            },
+                            Ok(false) => {},
+                            Err(_) => return Err::OperationFailed,
                         }
                     }
-                    Err::OperationFailed
-                })
+                }
+                Err::OperationFailed
             })
         })
-    }
+    })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn sub_receive_msg(r: *mut *const UnwrappedMessage, user: *mut Subscriber, link: *const Address) -> Err {
-    unsafe {
-        r.as_mut().map_or(Err::NullArgument, |r| {
-            user.as_mut().map_or(Err::NullArgument, |user| {
-                link.as_ref().map_or(Err::NullArgument, |link| {
-                    user.receive_msg(link).map_or(Err::OperationFailed, |u| {
-                        *r = safe_into_ptr(u);
-                        Err::Ok
-                    })
+    r.as_mut().map_or(Err::NullArgument, |r| {
+        user.as_mut().map_or(Err::NullArgument, |user| {
+            link.as_ref().map_or(Err::NullArgument, |link| {
+                user.receive_msg(link).map_or(Err::OperationFailed, |u| {
+                    *r = safe_into_ptr(u);
+                    Err::Ok
                 })
             })
         })
-    }
+    })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn sub_fetch_next_msgs(r: *mut *const UnwrappedMessages, user: *mut Subscriber) -> Err {
-    unsafe {
-        r.as_mut().map_or(Err::NullArgument, |r| {
-            user.as_mut().map_or(Err::NullArgument, |user| {
-                let m = user.fetch_next_msgs();
-                *r = safe_into_ptr(m);
-                Err::Ok
-            })
+    r.as_mut().map_or(Err::NullArgument, |r| {
+        user.as_mut().map_or(Err::NullArgument, |user| {
+            let m = user.fetch_next_msgs();
+            *r = safe_into_ptr(m);
+            Err::Ok
         })
-    }
+    })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn sub_sync_state(r: *mut *const UnwrappedMessages, user: *mut Subscriber) -> Err {
-    unsafe {
-        r.as_mut().map_or(Err::NullArgument, |r| {
-            user.as_mut().map_or(Err::NullArgument, |user| {
-                let mut ms = Vec::new();
-                loop {
-                    let m = user.fetch_next_msgs();
-                    if m.is_empty() {
-                        break;
-                    }
-                    ms.extend(m);
+    r.as_mut().map_or(Err::NullArgument, |r| {
+        user.as_mut().map_or(Err::NullArgument, |user| {
+            let mut ms = Vec::new();
+            loop {
+                let m = user.fetch_next_msgs();
+                if m.is_empty() {
+                    break;
                 }
-                *r = safe_into_ptr(ms);
-                Err::Ok
-            })
+                ms.extend(m);
+            }
+            *r = safe_into_ptr(ms);
+            Err::Ok
         })
-    }
+    })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn sub_fetch_state(user: *mut Subscriber) -> *const UserState {
-    unsafe {
-        user.as_mut().map_or(null(), |user| {
-            user.fetch_state().map_or(null(), |state| {
-                safe_into_ptr(state)
-            })
+    user.as_mut().map_or(null(), |user| {
+        user.fetch_state().map_or(null(), |state| {
+            safe_into_ptr(state)
         })
-    }
+    })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn sub_store_psk(user: *mut Subscriber, psk_seed_str: *const c_char) -> *const PskId {
-    unsafe {
-        let psk_seed = CStr::from_ptr(psk_seed_str).to_str().unwrap();
-        user.as_mut().map_or(null(), |user| {
-            let psk = psk_from_seed(psk_seed.as_ref());
-            let pskid = pskid_from_psk(&psk);
-            user.store_psk(pskid.clone(), psk);
-            safe_into_ptr(pskid)
-        })
-    }
+    let psk_seed = CStr::from_ptr(psk_seed_str).to_str().unwrap();
+    user.as_mut().map_or(null(), |user| {
+        let psk = psk_from_seed(psk_seed.as_ref());
+        let pskid = pskid_from_psk(&psk);
+        user.store_psk(pskid, psk);
+        safe_into_ptr(pskid)
+    })
 }
 

--- a/bindings/c/src/api/sub.rs
+++ b/bindings/c/src/api/sub.rs
@@ -400,3 +400,17 @@ pub extern "C" fn sub_fetch_state(user: *mut Subscriber) -> *const UserState {
         })
     }
 }
+
+#[no_mangle]
+pub extern "C" fn sub_store_psk(user: *mut Subscriber, psk_str: *const c_char) -> *const PskId {
+    unsafe {
+        let psk = CStr::from_ptr(psk_str).to_str().unwrap();
+        user.as_mut().map_or(null(), |user| {
+            psk_from_str(psk).as_ref().map_or(null(),|psk| {
+                let pskid = user.store_psk(*psk);
+                safe_into_ptr(pskid)
+            })
+        })
+    }
+}
+

--- a/bindings/c/src/api/sub.rs
+++ b/bindings/c/src/api/sub.rs
@@ -4,7 +4,7 @@ pub type Subscriber = iota_streams::app_channels::api::tangle::Subscriber<Transp
 
 /// Create a new subscriber
 #[no_mangle]
-pub extern "C" fn sub_new(
+pub unsafe extern "C" fn sub_new(
     c_seed: *const c_char,
     c_encoding: *const c_char,
     payload_length: size_t,
@@ -19,7 +19,7 @@ pub extern "C" fn sub_new(
 
 /// Recover an existing channel from seed and existing announcement message
 #[no_mangle]
-pub extern "C" fn sub_recover(
+pub unsafe extern "C" fn sub_recover(
     c_seed: *const c_char,
     c_ann_address: *const Address,
     transport: *mut TransportWrap
@@ -38,7 +38,7 @@ pub extern "C" fn sub_recover(
 
 /// Import an Author instance from an encrypted binary array
 #[no_mangle]
-pub extern "C" fn sub_import(
+pub unsafe extern "C" fn sub_import(
     buffer: Buffer,
     password: *const c_char,
     transport: *mut TransportWrap,
@@ -59,7 +59,7 @@ pub extern "C" fn sub_import(
 }
 
 #[no_mangle]
-pub extern "C" fn sub_export(
+pub unsafe extern "C" fn sub_export(
     user: *mut Subscriber,
     password: *const c_char
 ) -> Buffer {
@@ -79,7 +79,7 @@ pub extern "C" fn sub_drop(user: *mut Subscriber) {
 
 /// Channel app instance.
 #[no_mangle]
-pub extern "C" fn sub_channel_address(user: *const Subscriber) -> *const ChannelAddress {
+pub unsafe extern "C" fn sub_channel_address(user: *const Subscriber) -> *const ChannelAddress {
     unsafe {
         user.as_ref().map_or(null(), |user| {
             user.channel_address().map_or(null(), |channel_address| {
@@ -90,7 +90,7 @@ pub extern "C" fn sub_channel_address(user: *const Subscriber) -> *const Channel
 }
 
 #[no_mangle]
-pub extern "C" fn sub_is_multi_branching(user: *const Subscriber) -> uint8_t {
+pub unsafe extern "C" fn sub_is_multi_branching(user: *const Subscriber) -> uint8_t {
     unsafe {
         user.as_ref().map_or(0, |user| {
             if user.is_multi_branching() { 1 } else { 0 }
@@ -99,7 +99,7 @@ pub extern "C" fn sub_is_multi_branching(user: *const Subscriber) -> uint8_t {
 }
 
 #[no_mangle]
-pub extern "C" fn sub_get_public_key(user: *const Subscriber) -> *const PublicKey {
+pub unsafe extern "C" fn sub_get_public_key(user: *const Subscriber) -> *const PublicKey {
     unsafe {
         user.as_ref().map_or(null(), |user| {
             user.get_pk() as *const PublicKey
@@ -108,7 +108,7 @@ pub extern "C" fn sub_get_public_key(user: *const Subscriber) -> *const PublicKe
 }
 
 #[no_mangle]
-pub extern "C" fn sub_is_registered(user: *const Subscriber) -> u8 {
+pub unsafe extern "C" fn sub_is_registered(user: *const Subscriber) -> u8 {
     unsafe {
         user.as_ref().map_or(0, |user| {
             if user.is_registered() { 1 } else { 0 }
@@ -117,7 +117,7 @@ pub extern "C" fn sub_is_registered(user: *const Subscriber) -> u8 {
 }
 
 #[no_mangle]
-pub extern "C" fn sub_unregister(user: *mut Subscriber) {
+pub unsafe extern "C" fn sub_unregister(user: *mut Subscriber) {
     unsafe {
         user.as_mut().map_or((), |user| {
             user.unregister();
@@ -127,7 +127,7 @@ pub extern "C" fn sub_unregister(user: *mut Subscriber) {
 
 /// Handle Channel app instance announcement.
 #[no_mangle]
-pub extern "C" fn sub_receive_announce(user: *mut Subscriber, link: *const Address) -> Err {
+pub unsafe extern "C" fn sub_receive_announce(user: *mut Subscriber, link: *const Address) -> Err {
     unsafe {
         user.as_mut().map_or(Err::NullArgument, |user| {
             link.as_ref().map_or(Err::NullArgument, |link| {
@@ -139,7 +139,7 @@ pub extern "C" fn sub_receive_announce(user: *mut Subscriber, link: *const Addre
 
 /// Subscribe to a Channel app instance.
 #[no_mangle]
-pub extern "C" fn sub_send_subscribe(r: *mut *const Address, user: *mut Subscriber, announcement_link: *const Address) -> Err {
+pub unsafe extern "C" fn sub_send_subscribe(r: *mut *const Address, user: *mut Subscriber, announcement_link: *const Address) -> Err {
     unsafe {
         r.as_mut().map_or(Err::NullArgument, |r| {
             user.as_mut().map_or(Err::NullArgument, |user| {
@@ -157,7 +157,7 @@ pub extern "C" fn sub_send_subscribe(r: *mut *const Address, user: *mut Subscrib
 }
 
 #[no_mangle]
-pub extern "C" fn sub_send_tagged_packet(
+pub unsafe extern "C" fn sub_send_tagged_packet(
     r: *mut MessageLinks,
     user: *mut Subscriber,
     link_to: MessageLinks,
@@ -198,7 +198,7 @@ pub extern "C" fn sub_send_tagged_packet(
 }
 
 #[no_mangle]
-pub extern "C" fn sub_send_signed_packet(
+pub unsafe extern "C" fn sub_send_signed_packet(
     r: *mut MessageLinks,
     user: *mut Subscriber,
     link_to: MessageLinks,
@@ -241,7 +241,7 @@ pub extern "C" fn sub_send_signed_packet(
 
 /// Process a keyload message
 #[no_mangle]
-pub extern "C" fn sub_receive_keyload(user: *mut Subscriber, link: *const Address) -> Err {
+pub unsafe extern "C" fn sub_receive_keyload(user: *mut Subscriber, link: *const Address) -> Err {
     unsafe {
         user.as_mut().map_or(Err::NullArgument, |user| {
             link.as_ref().map_or(Err::NullArgument, |link| {
@@ -253,7 +253,7 @@ pub extern "C" fn sub_receive_keyload(user: *mut Subscriber, link: *const Addres
 }
 
 #[no_mangle]
-pub extern "C" fn sub_receive_sequence(r: *mut *const Address, user: *mut Subscriber, link: *const Address) -> Err {
+pub unsafe extern "C" fn sub_receive_sequence(r: *mut *const Address, user: *mut Subscriber, link: *const Address) -> Err {
     unsafe {
         r.as_mut().map_or(Err::NullArgument, |r| {
             user.as_mut().map_or(Err::NullArgument, |user| {
@@ -270,7 +270,7 @@ pub extern "C" fn sub_receive_sequence(r: *mut *const Address, user: *mut Subscr
 
 /// Process a Tagged packet message
 #[no_mangle]
-pub extern "C" fn sub_receive_tagged_packet(r: *mut PacketPayloads, user: *mut Subscriber, link: *const Address) -> Err {
+pub unsafe extern "C" fn sub_receive_tagged_packet(r: *mut PacketPayloads, user: *mut Subscriber, link: *const Address) -> Err {
     unsafe {
         r.as_mut().map_or(Err::NullArgument, |r| {
             user.as_mut().map_or(Err::NullArgument, |user| {
@@ -288,7 +288,7 @@ pub extern "C" fn sub_receive_tagged_packet(r: *mut PacketPayloads, user: *mut S
 
 /// Process a Signed packet message
 #[no_mangle]
-pub extern "C" fn sub_receive_signed_packet(r: *mut PacketPayloads, user: *mut Subscriber, link: *const Address) -> Err {
+pub unsafe extern "C" fn sub_receive_signed_packet(r: *mut PacketPayloads, user: *mut Subscriber, link: *const Address) -> Err {
     unsafe {
         r.as_mut().map_or(Err::NullArgument, |r| {
             user.as_mut().map_or(Err::NullArgument, |user| {
@@ -305,7 +305,7 @@ pub extern "C" fn sub_receive_signed_packet(r: *mut PacketPayloads, user: *mut S
 }
 
 #[no_mangle]
-pub extern "C" fn sub_gen_next_msg_ids(user: *mut Subscriber) -> *const NextMsgIds {
+pub unsafe extern "C" fn sub_gen_next_msg_ids(user: *mut Subscriber) -> *const NextMsgIds {
     unsafe {
         user.as_mut().map_or(null(), |user| {
             let next_msg_ids = user.gen_next_msg_ids(user.is_multi_branching());
@@ -315,7 +315,7 @@ pub extern "C" fn sub_gen_next_msg_ids(user: *mut Subscriber) -> *const NextMsgI
 }
 
 #[no_mangle]
-pub extern "C" fn sub_receive_keyload_from_ids(r: *mut MessageLinks, user: *mut Subscriber, next_msg_ids: *const NextMsgIds) -> Err {
+pub unsafe extern "C" fn sub_receive_keyload_from_ids(r: *mut MessageLinks, user: *mut Subscriber, next_msg_ids: *const NextMsgIds) -> Err {
     unsafe {
         r.as_mut().map_or(Err::NullArgument, |r| {
             user.as_mut().map_or(Err::NullArgument, |user| {
@@ -342,7 +342,7 @@ pub extern "C" fn sub_receive_keyload_from_ids(r: *mut MessageLinks, user: *mut 
 }
 
 #[no_mangle]
-pub extern "C" fn sub_receive_msg(r: *mut *const UnwrappedMessage, user: *mut Subscriber, link: *const Address) -> Err {
+pub unsafe extern "C" fn sub_receive_msg(r: *mut *const UnwrappedMessage, user: *mut Subscriber, link: *const Address) -> Err {
     unsafe {
         r.as_mut().map_or(Err::NullArgument, |r| {
             user.as_mut().map_or(Err::NullArgument, |user| {
@@ -358,7 +358,7 @@ pub extern "C" fn sub_receive_msg(r: *mut *const UnwrappedMessage, user: *mut Su
 }
 
 #[no_mangle]
-pub extern "C" fn sub_fetch_next_msgs(r: *mut *const UnwrappedMessages, user: *mut Subscriber) -> Err {
+pub unsafe extern "C" fn sub_fetch_next_msgs(r: *mut *const UnwrappedMessages, user: *mut Subscriber) -> Err {
     unsafe {
         r.as_mut().map_or(Err::NullArgument, |r| {
             user.as_mut().map_or(Err::NullArgument, |user| {
@@ -371,7 +371,7 @@ pub extern "C" fn sub_fetch_next_msgs(r: *mut *const UnwrappedMessages, user: *m
 }
 
 #[no_mangle]
-pub extern "C" fn sub_sync_state(r: *mut *const UnwrappedMessages, user: *mut Subscriber) -> Err {
+pub unsafe extern "C" fn sub_sync_state(r: *mut *const UnwrappedMessages, user: *mut Subscriber) -> Err {
     unsafe {
         r.as_mut().map_or(Err::NullArgument, |r| {
             user.as_mut().map_or(Err::NullArgument, |user| {
@@ -391,7 +391,7 @@ pub extern "C" fn sub_sync_state(r: *mut *const UnwrappedMessages, user: *mut Su
 }
 
 #[no_mangle]
-pub extern "C" fn sub_fetch_state(user: *mut Subscriber) -> *const UserState {
+pub unsafe extern "C" fn sub_fetch_state(user: *mut Subscriber) -> *const UserState {
     unsafe {
         user.as_mut().map_or(null(), |user| {
             user.fetch_state().map_or(null(), |state| {
@@ -402,7 +402,7 @@ pub extern "C" fn sub_fetch_state(user: *mut Subscriber) -> *const UserState {
 }
 
 #[no_mangle]
-pub extern "C" fn sub_store_psk(user: *mut Subscriber, psk_seed_str: *const c_char) -> *const PskId {
+pub unsafe extern "C" fn sub_store_psk(user: *mut Subscriber, psk_seed_str: *const c_char) -> *const PskId {
     unsafe {
         let psk_seed = CStr::from_ptr(psk_seed_str).to_str().unwrap();
         user.as_mut().map_or(null(), |user| {

--- a/bindings/c/src/api/sub.rs
+++ b/bindings/c/src/api/sub.rs
@@ -402,14 +402,14 @@ pub extern "C" fn sub_fetch_state(user: *mut Subscriber) -> *const UserState {
 }
 
 #[no_mangle]
-pub extern "C" fn sub_store_psk(user: *mut Subscriber, psk_str: *const c_char) -> *const PskId {
+pub extern "C" fn sub_store_psk(user: *mut Subscriber, psk_seed_str: *const c_char) -> *const PskId {
     unsafe {
-        let psk = CStr::from_ptr(psk_str).to_str().unwrap();
+        let psk_seed = CStr::from_ptr(psk_seed_str).to_str().unwrap();
         user.as_mut().map_or(null(), |user| {
-            psk_from_str(psk).as_ref().map_or(null(),|psk| {
-                let pskid = user.store_psk(*psk);
-                safe_into_ptr(pskid)
-            })
+            let psk = psk_from_seed(psk_seed.as_ref());
+            let pskid = pskid_from_psk(&psk);
+            user.store_psk(pskid.clone(), psk);
+            safe_into_ptr(pskid)
         })
     }
 }

--- a/bindings/wasm/src/author/authorw.rs
+++ b/bindings/wasm/src/author/authorw.rs
@@ -23,11 +23,12 @@ use iota_streams::{
         TransportOptions,
     },
     app_channels::api::{
-        make_psk,
+        psk_from_seed,
+        pskid_from_psk,
         tangle::{
             Address as ApiAddress,
             Author as ApiAuthor,
-        }
+        },
     },
     core::{
         prelude::{
@@ -35,10 +36,7 @@ use iota_streams::{
             String,
             ToString,
         },
-        psk::{
-            PskId,
-            PSKID_SIZE,
-        },
+        psk::pskid_to_hex_string,
     },
     ddml::types::*,
 };
@@ -125,9 +123,12 @@ impl Author {
     }
 
     #[wasm_bindgen(catch)]
-    pub fn store_psk(&self, psk_str: String) -> String {
-        let psk = make_psk(psk_str.as_bytes());
-        pskid_to_string(&self.author.borrow_mut().store_psk(psk))
+    pub fn store_psk(&self, psk_seed_str: String) -> String {
+        let psk = psk_from_seed(psk_seed_str.as_bytes());
+        let pskid = pskid_from_psk(&psk);
+        let pskid_str = pskid_to_hex_string(&pskid);
+        self.author.borrow_mut().store_psk(pskid, psk);
+        pskid_str
     }
 
     #[wasm_bindgen(catch)]

--- a/bindings/wasm/src/subscriber/subscriberw.rs
+++ b/bindings/wasm/src/subscriber/subscriberw.rs
@@ -16,9 +16,12 @@ use iota_streams::{
         },
         TransportOptions,
     },
-    app_channels::api::tangle::{
-        Address as ApiAddress,
-        Subscriber as ApiSubscriber,
+    app_channels::api::{
+        make_psk,
+        tangle::{
+            Address as ApiAddress,
+            Subscriber as ApiSubscriber,
+        }
     },
     core::prelude::{
         Rc,
@@ -104,6 +107,13 @@ impl Subscriber {
     #[wasm_bindgen(catch)]
     pub fn is_multi_branching(&self) -> Result<bool> {
         Ok(self.subscriber.borrow_mut().is_multi_branching())
+    }
+
+
+    #[wasm_bindgen(catch)]
+    pub fn store_psk(&self, psk_str: String) -> String {
+        let psk = make_psk(psk_str.as_bytes());
+        pskid_to_string(&self.subscriber.borrow_mut().store_psk(psk))
     }
 
     #[wasm_bindgen(catch)]

--- a/bindings/wasm/src/subscriber/subscriberw.rs
+++ b/bindings/wasm/src/subscriber/subscriberw.rs
@@ -17,15 +17,19 @@ use iota_streams::{
         TransportOptions,
     },
     app_channels::api::{
-        make_psk,
+        psk_from_seed,
+        pskid_from_psk,
         tangle::{
             Address as ApiAddress,
             Subscriber as ApiSubscriber,
-        }
+        },
     },
-    core::prelude::{
-        Rc,
-        String,
+    core::{
+        prelude::{
+            Rc,
+            String,
+        },
+        psk::pskid_to_hex_string,
     },
     ddml::types::*,
 };
@@ -109,11 +113,13 @@ impl Subscriber {
         Ok(self.subscriber.borrow_mut().is_multi_branching())
     }
 
-
     #[wasm_bindgen(catch)]
-    pub fn store_psk(&self, psk_str: String) -> String {
-        let psk = make_psk(psk_str.as_bytes());
-        pskid_to_string(&self.subscriber.borrow_mut().store_psk(psk))
+    pub fn store_psk(&self, psk_seed_str: String) -> String {
+        let psk = psk_from_seed(psk_seed_str.as_bytes());
+        let pskid = pskid_from_psk(&psk);
+        let pskid_str = pskid_to_hex_string(&pskid);
+        self.subscriber.borrow_mut().store_psk(pskid, psk);
+        pskid_str
     }
 
     #[wasm_bindgen(catch)]

--- a/bindings/wasm/src/types/mod.rs
+++ b/bindings/wasm/src/types/mod.rs
@@ -21,14 +21,16 @@ use iota_streams::{
         PublicKey,
         UnwrappedMessage,
     },
-    core::prelude::{
-        Rc,
-        String,
-        ToString,
-    },
-    core::psk::{
-        pskid_from_hex_str,
-        pskid_to_hex_string,
+    core::{
+        prelude::{
+            Rc,
+            String,
+            ToString,
+        },
+        psk::{
+            pskid_from_hex_str,
+            pskid_to_hex_string,
+        },
     },
     ddml::types::hex,
 };

--- a/bindings/wasm/src/types/mod.rs
+++ b/bindings/wasm/src/types/mod.rs
@@ -18,20 +18,24 @@ use iota_streams::{
     app_channels::api::tangle::{
         Address as ApiAddress,
         MessageContent,
-        UnwrappedMessage,
         PublicKey,
+        UnwrappedMessage,
     },
     core::prelude::{
         Rc,
         String,
         ToString,
     },
+    core::psk::{
+        pskid_from_hex_str,
+        pskid_to_hex_string,
+    },
     ddml::types::hex,
 };
 use wasm_bindgen::prelude::*;
 
-use js_sys::Array;
 use iota_streams::core::psk::PskId;
+use js_sys::Array;
 
 pub type Result<T> = core::result::Result<T, JsValue>;
 pub fn to_result<T, E: ToString>(r: core::result::Result<T, E>) -> Result<T> {
@@ -236,27 +240,22 @@ impl PskIds {
     }
 
     pub fn add(&mut self, id: String) -> Result<()> {
-        self.ids.push(pskid_from_string(&id)?);
+        let pskid = to_result(pskid_from_hex_str(&id))?;
+        self.ids.push(pskid);
         Ok(())
     }
 
     pub fn get_ids(&self) -> Array {
-        self.ids.iter().map(|pskid| JsValue::from(pskid_to_string(pskid))).collect()
+        self.ids
+            .iter()
+            .map(|pskid| JsValue::from(pskid_to_hex_string(pskid)))
+            .collect()
     }
 }
 
 #[wasm_bindgen]
 pub struct PublicKeys {
     pub(crate) pks: Vec<PublicKey>,
-}
-
-pub(crate) fn pskid_to_string(pskid: &PskId) -> String {
-    hex::encode(pskid.as_slice())
-}
-
-pub(crate) fn pskid_from_string(hex_id: &str) -> Result<PskId> {
-    let bytes = to_result(hex::decode(hex_id))?;
-    Ok(PskId::clone_from_slice(&bytes))
 }
 
 pub(crate) fn public_key_to_string(pk: &PublicKey) -> String {
@@ -280,7 +279,10 @@ impl PublicKeys {
     }
 
     pub fn get_pks(&self) -> Array {
-        self.pks.iter().map(|pk| JsValue::from(public_key_to_string(pk))).collect()
+        self.pks
+            .iter()
+            .map(|pk| JsValue::from(public_key_to_string(pk)))
+            .collect()
     }
 }
 

--- a/docs/libraries/c/api_reference.md
+++ b/docs/libraries/c/api_reference.md
@@ -221,6 +221,15 @@ Fetch the current user state to see the latest links for each publisher
 | author          | `author_t *`                  | Author instance                     |
 
 
+#### auth_store_state(author, psk): pskid_t 
+Stores a given Pre Shared Key (Psk) into the Author instance, returning a Pre Shared Key Id (PskId) 
+
+| Param           | Type                                   | Description              |
+| --------------- | -------------------------------------- | ------------------------ |
+| author          | `author_t *`                           | Author instance          |
+| psk             | `char const *`                         | Unique Pre Shared Key    |
+**Returns:** A PskId representing the Psk stored in the instance.
+
 
 ### Subscriber 
 
@@ -455,6 +464,17 @@ Fetch the current subscriber state to see the latest links for each publisher
 | subscriber       | `subscriber_t *`             | Subscriber instance                 |
 
 
+#### sub_store_state(subscriber, psk): pskid_t 
+Stores a given Pre Shared Key (Psk) into the Subscriber instance, returning a Pre Shared Key Id (PskId) 
+
+| Param           | Type                                   | Description              |
+| --------------- | -------------------------------------- | ------------------------ |
+| author          | `subscriber_t *`                       | Subscriber instance      |
+| psk             | `char const *`                         | Unique Pre Shared Key    |
+**Returns:** A PskId representing the Psk stored in the instance.
+
+
+
 ## Types
 
 ### Err
@@ -683,6 +703,14 @@ A 32 Byte Pre Shared Key
 
 ### PskId 
 Array of 16 bytes representing the identifier of a 32 byte [`Psk`](#Psk)
+
+#### pskid_as_str(pskid)
+Drop a rust allocated string from memory 
+
+| Param           | Type                          | Description                         |
+| --------------- | ----------------------------- | ----------------------------------- |
+| pskid           | `pskid_t const *`             | A Pre Shared Key Identifier         |
+**Returns:** String representation of the PskId object
 
 ### PskIds 
 An array of [`PskId`](#PskId)'s

--- a/docs/libraries/wasm/api_reference.md
+++ b/docs/libraries/wasm/api_reference.md
@@ -186,6 +186,13 @@ Fetch the next message sent by each publisher (empty array if none are present).
 | --------------- | ----------------------------- | ----------------------------------- |
 **Returns:** An array of NextMsgId wrappers for each publisher in the channel.
 
+#### store_psk(psk): String 
+Store a Pre Shared Key (Psk) and retrieve the Pre Shared Key Id (PskId) for use in keyload messages 
+| Param           | Type                          | Description                         |
+| --------------- | ----------------------------- | ----------------------------------- |
+| psk             | String                        | Pre shared key in string format     |
+
+**Returns:** A PskId String representing the Psk in store.
 
 
 ### Subscriber
@@ -360,6 +367,13 @@ Fetch the next message sent by each publisher (empty array if none are present).
 | --------------- | ----------------------------- | ----------------------------------- |
 **Returns:** An array of User Response wrappers around the retrieved messages.
 
+#### store_psk(psk): String 
+Store a Pre Shared Key (Psk) and retrieve the Pre Shared Key Id (PskId) for use in keyload messages 
+| Param           | Type                          | Description                         |
+| --------------- | ----------------------------- | ----------------------------------- |
+| psk             | String                        | Pre shared key in string format     |
+
+**Returns:** A PskId String representing the Psk in store.
 
 ## Types
 Generic Types and Primitives used in Wasm API:

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -848,7 +848,6 @@ dependencies = [
  "futures",
  "hex",
  "iota-client",
- "iota-crypto 0.5.1 (git+https://github.com/iotaledger/crypto.rs?branch=dev)",
  "iota-streams-core",
  "iota-streams-core-edsig",
  "iota-streams-ddml",
@@ -887,6 +886,7 @@ dependencies = [
  "displaydoc",
  "hashbrown 0.8.2",
  "hex",
+ "iota-crypto 0.5.1 (git+https://github.com/iotaledger/crypto.rs?branch=dev)",
  "rand 0.7.3",
 ]
 

--- a/examples/src/branching/utils.rs
+++ b/examples/src/branching/utils.rs
@@ -7,7 +7,7 @@ use iota_streams::{
     },
 };
 
-pub fn s_fetch_next_messages<T: Transport>(subscriber: &mut Subscriber<T>) {
+pub fn s_fetch_next_messages<T: Transport + Clone>(subscriber: &mut Subscriber<T>) {
     let mut exists = true;
 
     while exists {
@@ -25,7 +25,7 @@ pub fn s_fetch_next_messages<T: Transport>(subscriber: &mut Subscriber<T>) {
     }
 }
 
-pub fn a_fetch_next_messages<T: Transport>(author: &mut Author<T>) {
+pub fn a_fetch_next_messages<T: Transport + Clone>(author: &mut Author<T>) {
     let mut exists = true;
 
     while exists {

--- a/iota-streams-app-channels/src/api/mod.rs
+++ b/iota-streams-app-channels/src/api/mod.rs
@@ -14,3 +14,16 @@ pub mod user;
 /// Tangle-specific Channel API.
 #[cfg(all(feature = "tangle"))]
 pub mod tangle;
+
+use iota_streams_core::psk::*;
+use iota_streams_core_keccak::sponge::prp::keccak::KeccakF1600;
+
+/// Makes a PSK from an arbitrary byte array
+pub fn make_psk(bytes: &[u8]) -> Psk {
+    psk_from_seed::<KeccakF1600>(bytes)
+}
+
+/// Makes a PskId from an arbitrary byte array
+pub fn make_pskid(bytes: &[u8]) -> PskId {
+    pskid_from_seed::<KeccakF1600>(bytes)
+}

--- a/iota-streams-app-channels/src/api/mod.rs
+++ b/iota-streams-app-channels/src/api/mod.rs
@@ -15,15 +15,32 @@ pub mod user;
 #[cfg(all(feature = "tangle"))]
 pub mod tangle;
 
-use iota_streams_core::psk::*;
+use iota_streams_core::psk;
+pub use iota_streams_core::psk::{
+    Psk,
+    PskId,
+};
 use iota_streams_core_keccak::sponge::prp::keccak::KeccakF1600;
 
-/// Makes a PSK from an arbitrary byte array
-pub fn make_psk(bytes: &[u8]) -> Psk {
-    psk_from_seed::<KeccakF1600>(bytes)
+/// Default spongos PRP.
+pub type DefaultF = KeccakF1600;
+
+/// Derive a Psk from a secret seed
+pub fn psk_from_seed(seed_bytes: &[u8]) -> Psk {
+    psk::psk_from_seed::<DefaultF>(seed_bytes)
 }
 
-/// Makes a PskId from an arbitrary byte array
-pub fn make_pskid(bytes: &[u8]) -> PskId {
-    pskid_from_seed::<KeccakF1600>(bytes)
+/// Derive a PskId from a secret seed
+pub fn pskid_from_psk(psk: &Psk) -> PskId {
+    psk::pskid_from_psk::<DefaultF>(psk)
+}
+
+/// Derive a PskId from a secret seed
+pub fn pskid_from_seed(seed_bytes: &[u8]) -> PskId {
+    psk::pskid_from_seed::<DefaultF>(seed_bytes)
+}
+
+/// Create a PskId from a string or it's hash if the string is too long
+pub fn pskid_from_str(id: &str) -> PskId {
+    psk::pskid_from_str::<DefaultF>(id)
 }

--- a/iota-streams-app-channels/src/api/tangle/author.rs
+++ b/iota-streams-app-channels/src/api/tangle/author.rs
@@ -64,8 +64,8 @@ impl<Trans> Author<Trans> {
     }
 
     /// Store a PSK in the user instance, returns the PskId for identifying purposes in keyloads
-    pub fn store_psk(&mut self, psk: Psk) -> PskId {
-        self.user.store_psk(psk)
+    pub fn store_psk(&mut self, pskid: PskId, psk: Psk) {
+        self.user.store_psk(pskid, psk)
     }
 
     /// Generate a vector containing the next sequenced message identifier for each publishing

--- a/iota-streams-app-channels/src/api/tangle/author.rs
+++ b/iota-streams-app-channels/src/api/tangle/author.rs
@@ -64,6 +64,10 @@ impl<Trans> Author<Trans> {
     }
 
     /// Store a PSK in the user instance, returns the PskId for identifying purposes in keyloads
+    ///
+    ///   # Arguments
+    ///   * `pskid` - An identifier representing a pre shared key
+    ///   * `psk` - A pre shared key
     pub fn store_psk(&mut self, pskid: PskId, psk: Psk) {
         self.user.store_psk(pskid, psk)
     }

--- a/iota-streams-app-channels/src/api/tangle/mod.rs
+++ b/iota-streams-app-channels/src/api/tangle/mod.rs
@@ -29,15 +29,12 @@ pub use transport::{
     TransportOptions as _,
 };
 
+use super::DefaultF;
 use iota_streams_core::psk;
-use iota_streams_core_keccak::sponge::prp::keccak::KeccakF1600;
 use iota_streams_ddml::link_store::DefaultLinkStore;
 pub use iota_streams_ddml::types::Bytes;
 
 use iota_streams_core_edsig::signature::ed25519;
-
-/// Default spongos PRP.
-pub type DefaultF = KeccakF1600;
 
 /// Identifiers for Pre-Shared Keys
 pub type PskIds = psk::PskIds;

--- a/iota-streams-app-channels/src/api/tangle/msginfo.rs
+++ b/iota-streams-app-channels/src/api/tangle/msginfo.rs
@@ -8,7 +8,6 @@ use iota_streams_core::{
     sponge::prp::PRP,
     Errors::BadMessageInfo,
     Result,
-    LOCATION_LOG,
 };
 use iota_streams_ddml::{
     command::*,

--- a/iota-streams-app-channels/src/api/tangle/subscriber.rs
+++ b/iota-streams-app-channels/src/api/tangle/subscriber.rs
@@ -60,8 +60,8 @@ impl<Trans> Subscriber<Trans> {
     }
 
     /// Store a PSK in the user instance, returns the PskId for identifying purposes in keyloads
-    pub fn store_psk(&mut self, psk: Psk) -> PskId {
-        self.user.store_psk(psk)
+    pub fn store_psk(&mut self, pskid: PskId, psk: Psk) {
+        self.user.store_psk(pskid, psk)
     }
 
     /// Fetch the Address (application instance) of the channel.

--- a/iota-streams-app-channels/src/api/tangle/subscriber.rs
+++ b/iota-streams-app-channels/src/api/tangle/subscriber.rs
@@ -60,6 +60,10 @@ impl<Trans> Subscriber<Trans> {
     }
 
     /// Store a PSK in the user instance, returns the PskId for identifying purposes in keyloads
+    ///
+    ///   # Arguments
+    ///   * `pskid` - An identifier representing a pre shared key
+    ///   * `psk` - A pre shared key
     pub fn store_psk(&mut self, pskid: PskId, psk: Psk) {
         self.user.store_psk(pskid, psk)
     }

--- a/iota-streams-app-channels/src/api/tangle/test.rs
+++ b/iota-streams-app-channels/src/api/tangle/test.rs
@@ -13,7 +13,6 @@ use iota_streams_app::{
 use iota_streams_core::{
     try_or,
     Errors::*,
-    LOCATION_LOG,
 };
 
 use iota_streams_core::{

--- a/iota-streams-app-channels/src/api/tangle/user.rs
+++ b/iota-streams-app-channels/src/api/tangle/user.rs
@@ -13,7 +13,6 @@ use iota_streams_core::{
         UserNotRegistered,
     },
     Result,
-    LOCATION_LOG,
 };
 
 use super::*;
@@ -151,8 +150,8 @@ impl<Trans> User<Trans> {
         })
     }
 
-    pub fn store_psk(&mut self, psk: Psk) -> PskId {
-        self.user.store_psk(psk)
+    pub fn store_psk(&mut self, pskid: PskId, psk: Psk) {
+        self.user.store_psk(pskid, psk)
     }
 }
 

--- a/iota-streams-app-channels/src/api/tangle/user.rs
+++ b/iota-streams-app-channels/src/api/tangle/user.rs
@@ -28,7 +28,6 @@ use iota_streams_core::{
     },
     Errors::ChannelDuplication,
 };
-use iota_streams_ddml::types::GenericArray;
 
 type UserImp = api::user::User<DefaultF, Address, LinkGen, LinkStore, PkStore, PskStore>;
 
@@ -153,9 +152,7 @@ impl<Trans> User<Trans> {
     }
 
     pub fn store_psk(&mut self, psk: Psk) -> PskId {
-        let id: PskId = GenericArray::clone_from_slice(&psk[0..16]);
-        self.user.store_psk(id, psk);
-        id
+        self.user.store_psk(psk)
     }
 }
 

--- a/iota-streams-app-channels/src/api/user.rs
+++ b/iota-streams-app-channels/src/api/user.rs
@@ -888,8 +888,10 @@ where
         Ok(())
     }
 
-    pub fn store_psk(&mut self, pskid: psk::PskId, psk: psk::Psk) {
-        self.psk_store.insert(pskid, psk)
+    pub fn store_psk(&mut self, psk: psk::Psk) -> psk::PskId {
+        let pskid = psk::pskid_from_psk::<F>(&psk);
+        self.psk_store.insert(pskid, psk);
+        pskid
     }
 
     fn gen_next_msg_id(

--- a/iota-streams-app-channels/src/api/user.rs
+++ b/iota-streams-app-channels/src/api/user.rs
@@ -20,7 +20,6 @@ use iota_streams_core::{
     },
     try_or,
     Errors::*,
-    LOCATION_LOG,
 };
 use iota_streams_core_edsig::{
     key_exchange::x25519,
@@ -888,10 +887,8 @@ where
         Ok(())
     }
 
-    pub fn store_psk(&mut self, psk: psk::Psk) -> psk::PskId {
-        let pskid = psk::pskid_from_psk::<F>(&psk);
-        self.psk_store.insert(pskid, psk);
-        pskid
+    pub fn store_psk(&mut self, pskid: psk::PskId, psk: psk::Psk) {
+        self.psk_store.insert(pskid, psk)
     }
 
     fn gen_next_msg_id(

--- a/iota-streams-app-channels/src/message/subscribe.rs
+++ b/iota-streams-app-channels/src/message/subscribe.rs
@@ -49,7 +49,6 @@ use iota_streams_core::{
     Errors::MessageCreationFailure,
     Result,
     WrappedError,
-    LOCATION_LOG,
 };
 use iota_streams_core_edsig::{
     key_exchange::x25519,

--- a/iota-streams-app/Cargo.toml
+++ b/iota-streams-app/Cargo.toml
@@ -42,7 +42,6 @@ atomic_refcell = { version = "0.1.6", optional = true }
 
 # Dependencies for "client" feature
 iota-client = { git = "https://github.com/iotaledger/iota.rs", branch = "dev", default-features = false, optional = true }
-iota-crypto = { git = "https://github.com/iotaledger/crypto.rs", features = ["blake2b"], branch = "dev" }
 
 num_cpus = { version = "1.10", optional = true }
 

--- a/iota-streams-app/src/message/hdf.rs
+++ b/iota-streams-app/src/message/hdf.rs
@@ -5,7 +5,6 @@ use iota_streams_core::{
     sponge::prp::PRP,
     try_or,
     Errors::*,
-    LOCATION_LOG,
 };
 use iota_streams_ddml::{
     command::*,

--- a/iota-streams-app/src/message/pcf.rs
+++ b/iota-streams-app/src/message/pcf.rs
@@ -4,7 +4,6 @@ use iota_streams_core::{
     sponge::prp::PRP,
     try_or,
     Errors::ValueOutOfRange,
-    LOCATION_LOG,
 };
 use iota_streams_ddml::{
     command::*,

--- a/iota-streams-app/src/message/prepared.rs
+++ b/iota-streams-app/src/message/prepared.rs
@@ -6,7 +6,6 @@ use iota_streams_core::{
     sponge::prp::PRP,
     try_or,
     Errors::OutputStreamNotFullyConsumed,
-    LOCATION_LOG,
 };
 use iota_streams_ddml::{
     command::{

--- a/iota-streams-app/src/transport/bucket.rs
+++ b/iota-streams-app/src/transport/bucket.rs
@@ -9,7 +9,6 @@ use iota_streams_core::{
         HashMap,
     },
     Errors::MessageLinkNotFound,
-    LOCATION_LOG,
 };
 
 #[cfg(feature = "async")]

--- a/iota-streams-app/src/transport/mod.rs
+++ b/iota-streams-app/src/transport/mod.rs
@@ -234,7 +234,6 @@ use iota_streams_core::{
         TransportNotAvailable,
     },
     WrappedError,
-    LOCATION_LOG,
 };
 
 #[cfg(feature = "tangle")]

--- a/iota-streams-app/src/transport/tangle/client.rs
+++ b/iota-streams-app/src/transport/tangle/client.rs
@@ -26,7 +26,6 @@ use iota_streams_core::{
     Errors::*,
     Result,
     WrappedError,
-    LOCATION_LOG,
 };
 
 use crate::{

--- a/iota-streams-app/src/transport/tangle/mod.rs
+++ b/iota-streams-app/src/transport/tangle/mod.rs
@@ -32,8 +32,9 @@ use iota_streams_core::{
         prp::PRP,
         spongos::Spongos,
     },
+    wrapped_err,
     Errors::BadHexFormat,
-    wrapped_err, WrappedError,
+    WrappedError,
 };
 use iota_streams_core_edsig::signature::ed25519;
 use iota_streams_ddml::{
@@ -142,12 +143,12 @@ impl TangleAddress {
         let appinst = AppInst::from_str(appinst_str)
             .map_err(|e| wrapped_err!(BadHexFormat(appinst_str.into()), WrappedError(e)))?;
 
-        let msgid = MsgId::from_str(msgid_str)
-            .map_err(|e| wrapped_err!(BadHexFormat(appinst_str.into()), WrappedError(e)))?;
+        let msgid =
+            MsgId::from_str(msgid_str).map_err(|e| wrapped_err!(BadHexFormat(appinst_str.into()), WrappedError(e)))?;
 
         Ok(TangleAddress {
-            appinst: appinst,
-            msgid: msgid,
+            appinst,
+            msgid,
         })
     }
 

--- a/iota-streams-app/src/transport/tangle/mod.rs
+++ b/iota-streams-app/src/transport/tangle/mod.rs
@@ -11,14 +11,13 @@ use core::{
     str::FromStr,
 };
 
-use crypto::hashes::{
-    blake2b,
-    Digest,
-};
-
 use iota_streams_core::Result;
 
 use iota_streams_core::{
+    crypto::hashes::{
+        blake2b,
+        Digest,
+    },
     prelude::{
         typenum::{
             U12,

--- a/iota-streams-app/src/transport/tangle/mod.rs
+++ b/iota-streams-app/src/transport/tangle/mod.rs
@@ -146,10 +146,7 @@ impl TangleAddress {
         let msgid =
             MsgId::from_str(msgid_str).map_err(|e| wrapped_err!(BadHexFormat(appinst_str.into()), WrappedError(e)))?;
 
-        Ok(TangleAddress {
-            appinst,
-            msgid,
-        })
+        Ok(TangleAddress { appinst, msgid })
     }
 
     #[allow(clippy::inherent_to_string_shadow_display)]

--- a/iota-streams-app/src/transport/tangle/mod.rs
+++ b/iota-streams-app/src/transport/tangle/mod.rs
@@ -32,9 +32,8 @@ use iota_streams_core::{
         prp::PRP,
         spongos::Spongos,
     },
-    try_or,
-    Errors::InvalidHex,
-    LOCATION_LOG,
+    Errors::BadHexFormat,
+    wrapped_err, WrappedError,
 };
 use iota_streams_core_edsig::signature::ed25519;
 use iota_streams_ddml::{
@@ -140,15 +139,15 @@ pub struct TangleAddress {
 
 impl TangleAddress {
     pub fn from_str(appinst_str: &str, msgid_str: &str) -> Result<Self> {
-        let appinst = AppInst::from_str(appinst_str);
-        try_or!(appinst.is_ok(), InvalidHex(appinst_str.into()))?;
+        let appinst = AppInst::from_str(appinst_str)
+            .map_err(|e| wrapped_err!(BadHexFormat(appinst_str.into()), WrappedError(e)))?;
 
-        let msgid = MsgId::from_str(msgid_str);
-        try_or!(msgid.is_ok(), InvalidHex(msgid_str.into()))?;
+        let msgid = MsgId::from_str(msgid_str)
+            .map_err(|e| wrapped_err!(BadHexFormat(appinst_str.into()), WrappedError(e)))?;
 
         Ok(TangleAddress {
-            appinst: appinst.unwrap(),
-            msgid: msgid.unwrap(),
+            appinst: appinst,
+            msgid: msgid,
         })
     }
 

--- a/iota-streams-core-edsig/src/key_exchange/x25519.rs
+++ b/iota-streams-core-edsig/src/key_exchange/x25519.rs
@@ -9,9 +9,7 @@ use iota_streams_core::{
         HashSet,
         Vec,
     },
-    println,
     Errors::KeyConversionFailure,
-    LOCATION_LOG,
 };
 pub use x25519_dalek::{
     EphemeralSecret,

--- a/iota-streams-core/Cargo.toml
+++ b/iota-streams-core/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/lib.rs"
 digest = { version = "0.9", default-features = false }
 #rand_core = { version = "0.5", default-features = false }
 rand = { version = "0.7", default-features = false, features = ["wasm-bindgen"]}
-hashbrown = { version = "0.8.2", default-features = false, optional = false, features = ["ahash"] }
+hashbrown = { version = "0.11.2", default-features = false, optional = false, features = ["ahash"] }
 hex = { version = "0.4", default-features = false, optional = false, features = ["alloc"] }
 anyhow = { version = "1.0.34", default-features = false, optional = false }
 

--- a/iota-streams-core/Cargo.toml
+++ b/iota-streams-core/Cargo.toml
@@ -24,7 +24,7 @@ digest = { version = "0.9", default-features = false }
 #rand_core = { version = "0.5", default-features = false }
 rand = { version = "0.7", default-features = false, features = ["wasm-bindgen"]}
 hashbrown = { version = "0.8.2", default-features = false, optional = false, features = ["ahash"] }
-hex = { version = "0.4", default-features = false, optional = false }
+hex = { version = "0.4", default-features = false, optional = false, features = ["alloc"] }
 anyhow = { version = "1.0.34", default-features = false, optional = false }
 
 # thiserror = { version = "1.0.22", default-features = false, optional = false }

--- a/iota-streams-core/Cargo.toml
+++ b/iota-streams-core/Cargo.toml
@@ -30,5 +30,7 @@ anyhow = { version = "1.0.34", default-features = false, optional = false }
 # thiserror = { version = "1.0.22", default-features = false, optional = false }
 displaydoc = { version = "0.2", default-features = false, optional = false }
 
+iota-crypto = { git = "https://github.com/iotaledger/crypto.rs", features = ["blake2b"], branch = "dev" }
+
 [dev-dependencies]
 criterion = "0.3"

--- a/iota-streams-core/src/errors/error_handler.rs
+++ b/iota-streams-core/src/errors/error_handler.rs
@@ -9,8 +9,8 @@ use core::fmt::Debug;
 #[macro_export]
 macro_rules! try_or {
     ($cond:expr, $err:expr) => {{
-        if LOCATION_LOG && !$cond {
-            println!("\n!!! Error occurred @ {}, {}", file!(), line!())
+        if $crate::LOCATION_LOG && !$cond {
+            $crate::println!("\n!!! Error occurred @ {}, {}", file!(), line!())
         }
         try_or($cond, $err)
     }};
@@ -19,8 +19,8 @@ macro_rules! try_or {
 #[macro_export]
 macro_rules! err {
     ($err:expr) => {{
-        if LOCATION_LOG {
-            println!("\n!!! Error occurred @ {}, {}", file!(), line!());
+        if $crate::LOCATION_LOG {
+            $crate::println!("\n!!! Error occurred @ {}, {}", file!(), line!());
         }
         err($err)
     }};
@@ -29,8 +29,8 @@ macro_rules! err {
 #[macro_export]
 macro_rules! panic_if_not {
     ($cond:expr) => {{
-        if LOCATION_LOG && !$cond {
-            println!("\n!!! Error occurred @ {}, {}", file!(), line!())
+        if $crate::LOCATION_LOG && !$cond {
+            $crate::println!("\n!!! Error occurred @ {}, {}", file!(), line!())
         }
         panic_if_not($cond)
     }};
@@ -39,8 +39,8 @@ macro_rules! panic_if_not {
 #[macro_export]
 macro_rules! wrapped_err {
     ($err:expr, $wrapped:expr) => {{
-        if LOCATION_LOG {
-            println!("\n!!! Error occurred @ {}, {}", file!(), line!());
+        if $crate::LOCATION_LOG {
+            $crate::println!("\n!!! Error occurred @ {}, {}", file!(), line!());
         }
         wrapped_err($err, $wrapped)
     }};

--- a/iota-streams-core/src/errors/error_messages.rs
+++ b/iota-streams-core/src/errors/error_messages.rs
@@ -22,6 +22,8 @@ pub enum Errors {
     SpongosNotCommitted,
     /// Link not found in store. (Possibly unimplemented)
     GenericLinkNotFound,
+    /// Input string {0} is not in hex format
+    BadHexFormat(String),
 
     //////////
     // Cryptographic
@@ -166,8 +168,6 @@ pub enum Errors {
     //////////
     /// Bytes are invalid. Values don't match (expected {0}, found {1}
     InvalidBytes(String, String),
-    /// Cannot process hex from {0}
-    InvalidHex(String),
     /// Squeezed tag is invalid. Unwrapped tag doesn't match (expected {0}, found {1}
     InvalidTagSqueeze(String, String),
     /// Squeezed hash is invalid. Unwrapped hash doesn't match (expected {0}, found {1}

--- a/iota-streams-core/src/lib.rs
+++ b/iota-streams-core/src/lib.rs
@@ -66,3 +66,5 @@ pub use errors::{
     error_handler::*,
     error_messages::*,
 };
+
+pub use crypto;

--- a/iota-streams-core/src/lib.rs
+++ b/iota-streams-core/src/lib.rs
@@ -1,4 +1,6 @@
 #![no_std]
+// TODO: Remove this after clippy fixes their false positive bug [https://github.com/rust-lang/rust-clippy/issues/7434]
+#![allow(clippy::nonstandard_macro_braces)]
 //#![feature(generic_associated_types)]
 
 #[cfg(not(feature = "std"))]

--- a/iota-streams-core/src/lib.rs
+++ b/iota-streams-core/src/lib.rs
@@ -14,19 +14,15 @@ extern crate std;
 #[cfg(not(feature = "std"))]
 #[macro_export]
 macro_rules! println {
-    () => {};
-    ($($arg:tt)*) => {
-        return ();
-    };
+    () => ({});
+    ($($arg:tt)*) => ({});
 }
 
 #[cfg(not(feature = "std"))]
 #[macro_export]
 macro_rules! print {
-    () => {};
-    ($($arg:tt)*) => {
-        return ();
-    };
+    () => ({});
+    ($($arg:tt)*) => ({});
 }
 
 // Reexport macro at the same level as `no_std`.

--- a/iota-streams-core/src/lib.rs
+++ b/iota-streams-core/src/lib.rs
@@ -14,15 +14,15 @@ extern crate std;
 #[cfg(not(feature = "std"))]
 #[macro_export]
 macro_rules! println {
-    () => ({});
-    ($($arg:tt)*) => ({});
+    () => {{}};
+    ($($arg:tt)*) => {{}};
 }
 
 #[cfg(not(feature = "std"))]
 #[macro_export]
 macro_rules! print {
-    () => ({});
-    ($($arg:tt)*) => ({});
+    () => {{}};
+    ($($arg:tt)*) => {{}};
 }
 
 // Reexport macro at the same level as `no_std`.

--- a/iota-streams-core/src/prng.rs
+++ b/iota-streams-core/src/prng.rs
@@ -84,6 +84,20 @@ impl<G: PRP> Prng<G> {
         }
     }
 
+    fn key_from_seed(seed: impl AsRef<[u8]>) -> KeyType<G> {
+        let mut s = Spongos::<G>::init();
+        s.absorb(seed);
+        s.commit();
+        let mut secret_key = KeyType::<G>::default();
+        s.squeeze(&mut secret_key);
+        secret_key
+    }
+
+    /// Derive secret key from seed and init PRNG with it.
+    pub fn init_with_seed(seed: impl AsRef<[u8]>) -> Self {
+        Self::init(Self::key_from_seed(seed))
+    }
+
     // TODO: PRNG randomness hierarchy via nonce: domain (seed, ed/x25519, session key, etc.), secret, counter.
     fn gen_with_spongos<'a>(&self, s: &mut Spongos<G>, nonces: &[&'a [u8]], rnds: &mut [&'a mut [u8]]) {
         // TODO: `dst` byte?

--- a/iota-streams-core/src/psk.rs
+++ b/iota-streams-core/src/psk.rs
@@ -15,8 +15,15 @@ use crate::{
         Vec,
     },
     prng,
-    sponge::{prp::PRP, spongos::Spongos},
-    Errors, try_or, Result, wrapped_err,WrappedError,
+    sponge::{
+        prp::PRP,
+        spongos::Spongos,
+    },
+    try_or,
+    wrapped_err,
+    Errors,
+    Result,
+    WrappedError,
 };
 
 /// Size of pre-shared key identifier.
@@ -62,8 +69,7 @@ pub fn pskid_from_seed<F: PRP>(seed_bytes: &[u8]) -> PskId {
 pub fn pskid_from_str<F: PRP>(id: &str) -> PskId {
     if id.as_bytes().len() < PSKID_SIZE {
         let mut pskid = PskId::default();
-        pskid.as_mut_slice()[..id.as_bytes().len()]
-            .copy_from_slice(id.as_bytes());
+        pskid.as_mut_slice()[..id.as_bytes().len()].copy_from_slice(id.as_bytes());
         pskid
     } else {
         let mut s = Spongos::<F>::init();
@@ -81,9 +87,12 @@ pub fn pskid_to_hex_string(pskid: &PskId) -> String {
 
 /// Create a PskId from hex string.
 pub fn pskid_from_hex_str(hex_str: &str) -> Result<PskId> {
-    let pskid_bytes = hex::decode(hex_str)
-        .map_err(|e| wrapped_err!(Errors::BadHexFormat(hex_str.into()), WrappedError(e)))?;
-    try_or!(PSKID_SIZE == pskid_bytes.len(), Errors::LengthMismatch(PSKID_SIZE, pskid_bytes.len()))?;
+    let pskid_bytes =
+        hex::decode(hex_str).map_err(|e| wrapped_err!(Errors::BadHexFormat(hex_str.into()), WrappedError(e)))?;
+    try_or!(
+        PSKID_SIZE == pskid_bytes.len(),
+        Errors::LengthMismatch(PSKID_SIZE, pskid_bytes.len())
+    )?;
     Ok(PskId::clone_from_slice(&pskid_bytes))
 }
 

--- a/iota-streams-core/src/psk.rs
+++ b/iota-streams-core/src/psk.rs
@@ -2,10 +2,6 @@
 //! (session) key exchange.
 
 use crate::{
-    crypto::hashes::{
-        blake2b,
-        Digest,
-    },
     prelude::{
         generic_array::{
             typenum::{
@@ -15,12 +11,12 @@ use crate::{
             GenericArray,
         },
         HashMap,
+        String,
         Vec,
     },
-    sponge::{
-        prp::PRP,
-        spongos::Spongos,
-    }
+    prng,
+    sponge::{prp::PRP, spongos::Spongos},
+    Errors, try_or, Result, wrapped_err,WrappedError,
 };
 
 /// Size of pre-shared key identifier.
@@ -47,31 +43,48 @@ pub type Psks = HashMap<PskId, Psk>;
 /// Container (set) of pre-shared key identifiers.
 pub type PskIds = [PskId];
 
-/// Make a Psk from arbitrary bytes
-pub fn psk_from_seed<F: PRP>(bytes: &[u8]) -> Psk {
-    let hash = blake2b::Blake2b256::digest(bytes);
-    let mut ctx = Spongos::<F>::init();
-    ctx.absorb(hash);
-    ctx.commit();
-    let mut id: Vec<u8> = vec![0; PSK_SIZE];
-    ctx.squeeze(&mut id);
-    GenericArray::clone_from_slice(&id)
+/// Derive a Psk from arbitrary secret seed bytes.
+pub fn psk_from_seed<F: PRP>(seed_bytes: &[u8]) -> Psk {
+    prng::Prng::<F>::init_with_seed(seed_bytes).gen_arr("PSK")
 }
 
-/// Make a PskId from arbitrary bytes
-pub fn pskid_from_seed<F: PRP>(bytes: &[u8]) -> PskId {
-    let hash = blake2b::Blake2b256::digest(bytes);
-    let mut ctx = Spongos::<F>::init();
-    ctx.absorb(hash);
-    ctx.commit();
-    let mut id: Vec<u8> = vec![0; PSKID_SIZE];
-    ctx.squeeze(&mut id);
-    GenericArray::clone_from_slice(&id)
-}
-
-/// Derive pskid from existing psk
+/// Derive a PskId from existing Psk.
 pub fn pskid_from_psk<F: PRP>(psk: &Psk) -> PskId {
-    pskid_from_seed::<F>(psk)
+    prng::Prng::<F>::init_with_seed(psk).gen_arr("PSKID")
+}
+
+/// Derive a PskId from the same seed that was used to derive the corresponding Psk.
+pub fn pskid_from_seed<F: PRP>(seed_bytes: &[u8]) -> PskId {
+    pskid_from_psk::<F>(&psk_from_seed::<F>(seed_bytes))
+}
+
+/// Make a PskId from string or it's hash if the string is too long.
+pub fn pskid_from_str<F: PRP>(id: &str) -> PskId {
+    if id.as_bytes().len() < PSKID_SIZE {
+        let mut pskid = PskId::default();
+        pskid.as_mut_slice()[..id.as_bytes().len()]
+            .copy_from_slice(id.as_bytes());
+        pskid
+    } else {
+        let mut s = Spongos::<F>::init();
+        s.absorb("PSKID");
+        s.absorb(id.as_bytes());
+        s.commit();
+        s.squeeze_arr()
+    }
+}
+
+/// Represent PskId bytes as hex string.
+pub fn pskid_to_hex_string(pskid: &PskId) -> String {
+    hex::encode(pskid.as_slice())
+}
+
+/// Create a PskId from hex string.
+pub fn pskid_from_hex_str(hex_str: &str) -> Result<PskId> {
+    let pskid_bytes = hex::decode(hex_str)
+        .map_err(|e| wrapped_err!(Errors::BadHexFormat(hex_str.into()), WrappedError(e)))?;
+    try_or!(PSKID_SIZE == pskid_bytes.len(), Errors::LengthMismatch(PSKID_SIZE, pskid_bytes.len()))?;
+    Ok(PskId::clone_from_slice(&pskid_bytes))
 }
 
 /// Select only pre-shared keys with given identifiers.
@@ -79,5 +92,5 @@ pub fn filter_psks<'a>(psks: &'a Psks, psk_ids: &'_ PskIds) -> Vec<IPsk<'a>> {
     psk_ids
         .iter()
         .filter_map(|psk_id| psks.get_key_value(psk_id))
-        .collect::<Vec<(&PskId, &Psk)>>()
+        .collect::<Vec<IPsk>>()
 }

--- a/iota-streams-core/src/sponge/spongos.rs
+++ b/iota-streams-core/src/sponge/spongos.rs
@@ -26,7 +26,6 @@ use crate::{
         SpongosNotCommitted,
     },
     Result,
-    LOCATION_LOG,
 };
 
 fn xor(s: &mut [u8], x: &[u8]) {

--- a/iota-streams-ddml/src/command/unwrap/absorb.rs
+++ b/iota-streams-ddml/src/command/unwrap/absorb.rs
@@ -25,7 +25,6 @@ use iota_streams_core::{
     sponge::prp::PRP,
     Errors::PublicKeyGenerationFailure,
     Result,
-    LOCATION_LOG,
 };
 use iota_streams_core_edsig::{
     key_exchange::x25519,

--- a/iota-streams-ddml/src/command/unwrap/ed25519.rs
+++ b/iota-streams-ddml/src/command/unwrap/ed25519.rs
@@ -21,7 +21,6 @@ use iota_streams_core::{
     wrapped_err,
     Errors::SignatureMismatch,
     WrappedError,
-    LOCATION_LOG,
 };
 use iota_streams_core_edsig::signature::ed25519;
 

--- a/iota-streams-ddml/src/command/unwrap/guard.rs
+++ b/iota-streams-ddml/src/command/unwrap/guard.rs
@@ -8,7 +8,6 @@ use crate::{
 use iota_streams_core::{
     try_or,
     Errors,
-    LOCATION_LOG,
 };
 
 impl<F, IS: io::IStream> Guard for Context<F, IS> {

--- a/iota-streams-ddml/src/command/unwrap/mask.rs
+++ b/iota-streams-ddml/src/command/unwrap/mask.rs
@@ -24,7 +24,6 @@ use iota_streams_core::{
     wrapped_err,
     Errors::PublicKeyGenerationFailure,
     WrappedError,
-    LOCATION_LOG,
 };
 use iota_streams_core_edsig::{
     key_exchange::x25519,

--- a/iota-streams-ddml/src/command/unwrap/squeeze.rs
+++ b/iota-streams-ddml/src/command/unwrap/squeeze.rs
@@ -10,7 +10,6 @@ use iota_streams_core::{
     sponge::prp::PRP,
     try_or,
     Errors::BadMac,
-    LOCATION_LOG,
 };
 
 /// External values are not encoded. Squeeze and compare tag trits.

--- a/iota-streams-ddml/src/command/wrap/ed25519.rs
+++ b/iota-streams-ddml/src/command/wrap/ed25519.rs
@@ -21,7 +21,6 @@ use iota_streams_core::{
     wrapped_err,
     Errors::SignatureFailure,
     WrappedError,
-    LOCATION_LOG,
 };
 use iota_streams_core_edsig::signature::ed25519;
 

--- a/iota-streams-ddml/src/command/wrap/guard.rs
+++ b/iota-streams-ddml/src/command/wrap/guard.rs
@@ -8,7 +8,6 @@ use crate::{
 use iota_streams_core::{
     try_or,
     Errors,
-    LOCATION_LOG,
 };
 
 impl<F, IS: io::OStream> Guard for Context<F, IS> {

--- a/iota-streams-ddml/src/command/wrap/x25519.rs
+++ b/iota-streams-ddml/src/command/wrap/x25519.rs
@@ -2,7 +2,6 @@
 use iota_streams_core::{
     err,
     Errors::NoStdRngMissing,
-    LOCATION_LOG,
 };
 
 use iota_streams_core::Result;

--- a/iota-streams-ddml/src/io.rs
+++ b/iota-streams-ddml/src/io.rs
@@ -12,7 +12,6 @@ use iota_streams_core::{
         StreamAllocationExceededOut,
     },
     Result,
-    LOCATION_LOG,
 };
 
 /// Write

--- a/iota-streams-ddml/src/link_store.rs
+++ b/iota-streams-ddml/src/link_store.rs
@@ -21,7 +21,6 @@ use iota_streams_core::{
         GenericLinkNotFound,
         MessageLinkNotFoundInTangle,
     },
-    LOCATION_LOG,
 };
 
 /// The `link` type is generic and transport-specific. Links can be address+tag pair


### PR DESCRIPTION
# Description of change
Add additional utility functions for psk usage to make it less strict and allow arbitrary key size usage. Also includes updates to the bindings to make sure `store_psk()` is available in them for v1.1.0.

## Type of change

Choose a type of change, and delete any options that are not relevant.
- Enhancement (a non-breaking change which adds functionality)
- Documentation Fix

## How the change has been tested
Previous existing examples all run, and so does Dominic's example with his now resolved issue.

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
