### PR TITLE
Feature reset state

### DIFF
--- a/bindings/c/include/iota_streams/channels.h
+++ b/bindings/c/include/iota_streams/channels.h
@@ -107,8 +107,8 @@ extern err_t transport_get_link_details(transport_details_t *details, transport_
 ////////////
 typedef struct Author author_t;
 
-extern err_t auth_new(author_t **auth, char const *seed, char const *encoding, size_t payload_length, uint8_t multi_branching, transport_t *transport);
-extern err_t auth_recover(author_t **auth, char const *seed, address_t const *announcement, uint8_t multi_branching, transport_t *transport);
+extern err_t auth_new(author_t **auth, char const *seed, uint8_t implementation, transport_t *transport);
+extern err_t auth_recover(author_t **auth, char const *seed, address_t const *announcement, uint8_t implementation, transport_t *transport);
 extern void auth_drop(author_t *);
 
 extern err_t auth_import(author_t **auth, buffer_t buffer, char const *password, transport_t *transport);
@@ -188,6 +188,7 @@ extern err_t sub_receive_msg(unwrapped_message_t const *umsg, subscriber_t *subs
 extern err_t sub_fetch_next_msgs(unwrapped_messages_t const **messages, subscriber_t *subscriber);
 extern err_t sub_sync_state(unwrapped_messages_t const **messages, subscriber_t *subscriber);
 extern err_t sub_fetch_state(user_state_t const **state, subscriber_t *subscriber);
+extern err_t sub_reset_state(subscriber_t *subscriber);
 // Store Psk
 extern err_t sub_store_psk(psk_id_t const **pskid, subscriber_t *subscriber, char const *psk);
 

--- a/bindings/c/src/api/auth.rs
+++ b/bindings/c/src/api/auth.rs
@@ -111,7 +111,7 @@ pub unsafe extern "C" fn auth_channel_address(addr: *mut *const ChannelAddress, 
                 Err::Ok
             })
         })
-    }
+    })
 }
 
 #[no_mangle]

--- a/bindings/c/src/api/sub.rs
+++ b/bindings/c/src/api/sub.rs
@@ -394,9 +394,9 @@ pub unsafe extern "C" fn sub_fetch_prev_msg(m: *mut *const UnwrappedMessage, use
     m.as_mut().map_or(Err::NullArgument, |m| {
         user.as_mut().map_or(Err::NullArgument, |user| {
             address.as_ref().map_or(Err::NullArgument, |addr| {
-                user.fetch_prev_msg(addr).map_or(Err::OperationFailed, |m| {
-                    *m = safe_into_ptr(m);
-                    Err::OK
+                user.fetch_prev_msg(addr).map_or(Err::OperationFailed, |msg| {
+                    *m = safe_into_ptr(msg);
+                    Err::Ok
                 })
             })
         })
@@ -408,8 +408,8 @@ pub unsafe extern "C" fn sub_fetch_prev_msgs(umsgs: *mut *const UnwrappedMessage
     umsgs.as_mut().map_or(Err::NullArgument, |umsgs| {
         user.as_mut().map_or(Err::NullArgument, |user| {
             address.as_ref().map_or(Err::NullArgument, |addr| {
-                user.fetch_prev_msgs(addr, num_msgs).map_or(Err::OperationFailed, |umsgs| {
-                    *umsgs = safe_into_ptr(umsgs);
+                user.fetch_prev_msgs(addr, num_msgs).map_or(Err::OperationFailed, |msgs| {
+                    *umsgs = safe_into_ptr(msgs);
                     Err::Ok
                 })
             })
@@ -445,6 +445,13 @@ pub unsafe extern "C" fn sub_fetch_state(state: *mut *const UserState, user: *mu
                 Err::Ok
             })
         })
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sub_reset_state(user: *mut Subscriber) -> Err {
+    user.as_mut().map_or(Err::NullArgument, |user| {
+        user.reset_state().map_or(Err::OperationFailed, |_| Err::Ok)
     })
 }
 

--- a/bindings/wasm/examples/node.js
+++ b/bindings/wasm/examples/node.js
@@ -38,6 +38,9 @@ async function main() {
   let ann_link_copy = ann_link.copy();
   await sub.clone().receive_announcement(ann_link_copy);
 
+  // copy state for comparison after reset later
+  let start_state = sub.fetch_state();
+
   console.log("Subscribing...");
   ann_link_copy = ann_link.copy();
   response = await sub.clone().send_subscribe(ann_link_copy);
@@ -94,6 +97,21 @@ async function main() {
       );
     }
   }
+
+  console.log("\nSubscriber resetting state");
+  sub.clone().reset_state();
+  let reset_state = sub.fetch_state();
+
+  var matches = true;
+  for (var i = 0; i < reset_state.length; i++) {
+    if (start_state[i].get_link().to_string() != reset_state[i].get_link().to_string() ||
+        start_state[i].get_seq_no() != reset_state[i].get_seq_no() ||
+        start_state[i].get_branch_no() != reset_state[i].get_branch_no()) {
+      matches = false;
+    }
+  }
+
+  if (matches) { console.log("States match"); } else { console.log("States do not match"); }
 
   console.log("\nAuthor fetching prev messages");
   let prev_msgs = await auth.clone().fetch_prev_msgs(last_link, 3);

--- a/bindings/wasm/examples/node.ts
+++ b/bindings/wasm/examples/node.ts
@@ -45,6 +45,9 @@ async function main() {
     let ann_link_copy = ann_link.copy();
     await sub.clone().receive_announcement(ann_link_copy);
 
+    // copy state for comparison after reset later
+    let start_state = sub.fetch_state();
+
     console.log("Subscribing...");
     ann_link_copy = ann_link.copy();
     response = await sub.clone().send_subscribe(ann_link_copy);
@@ -101,6 +104,21 @@ async function main() {
             );
         }
     }
+
+    console.log("\nSubscriber resetting state");
+    sub.clone().reset_state();
+    let reset_state = sub.fetch_state();
+
+    var matches = true;
+    for (var i = 0; i < reset_state.length; i++) {
+        if (start_state[i].get_link().to_string() != reset_state[i].get_link().to_string() ||
+            start_state[i].get_seq_no() != reset_state[i].get_seq_no() ||
+            start_state[i].get_branch_no() != reset_state[i].get_branch_no()) {
+            matches = false;
+        }
+    }
+
+    if (matches) { console.log("States match"); } else { console.log("States do not match"); }
 
     console.log("\nAuthor fetching prev messages");
     let prev_msgs = await auth.clone().fetch_prev_msgs(last_link, 3);

--- a/bindings/wasm/src/author/authorw.rs
+++ b/bindings/wasm/src/author/authorw.rs
@@ -411,17 +411,14 @@ impl Author {
 
     #[wasm_bindgen(catch)]
     pub fn fetch_state(&self) -> Result<Array> {
-        self.author
-            .borrow_mut()
-            .fetch_state()
-            .map_or_else(
-                |err| Err(JsValue::from_str(&err.to_string())),
-                |state_list| {
-                    Ok(state_list.into_iter()
-                        .map(|(pk, cursor)| JsValue::from(UserState::new(pk, cursor.into())))
-                        .collect()
-                    )
-                }
-            )
+        self.author.borrow_mut().fetch_state().map_or_else(
+            |err| Err(JsValue::from_str(&err.to_string())),
+            |state_list| {
+                Ok(state_list
+                    .into_iter()
+                    .map(|(pk, cursor)| JsValue::from(UserState::new(pk, cursor.into())))
+                    .collect())
+            },
+        )
     }
 }

--- a/bindings/wasm/src/author/authorw.rs
+++ b/bindings/wasm/src/author/authorw.rs
@@ -408,4 +408,20 @@ impl Author {
         }
         Ok(ids.into_iter().map(JsValue::from).collect())
     }
+
+    #[wasm_bindgen(catch)]
+    pub fn fetch_state(&self) -> Result<Array> {
+        self.author
+            .borrow_mut()
+            .fetch_state()
+            .map_or_else(
+                |err| Err(JsValue::from_str(&err.to_string())),
+                |state_list| {
+                    Ok(state_list.into_iter()
+                        .map(|(pk, cursor)| JsValue::from(UserState::new(pk, cursor.into())))
+                        .collect()
+                    )
+                }
+            )
+    }
 }

--- a/bindings/wasm/src/subscriber/subscriberw.rs
+++ b/bindings/wasm/src/subscriber/subscriberw.rs
@@ -357,18 +357,15 @@ impl Subscriber {
 
     #[wasm_bindgen(catch)]
     pub fn fetch_state(&self) -> Result<Array> {
-        self.subscriber
-            .borrow_mut()
-            .fetch_state()
-            .map_or_else(
-                |err| Err(JsValue::from_str(&err.to_string())),
-                |state_list| {
-                    Ok(state_list.into_iter()
-                        .map(|(pk, cursor)| JsValue::from(UserState::new(pk, cursor.into())))
-                        .collect()
-                    )
-                }
-            )
+        self.subscriber.borrow_mut().fetch_state().map_or_else(
+            |err| Err(JsValue::from_str(&err.to_string())),
+            |state_list| {
+                Ok(state_list
+                    .into_iter()
+                    .map(|(pk, cursor)| JsValue::from(UserState::new(pk, cursor.into())))
+                    .collect())
+            },
+        )
     }
 
     #[wasm_bindgen(catch)]

--- a/bindings/wasm/src/subscriber/subscriberw.rs
+++ b/bindings/wasm/src/subscriber/subscriberw.rs
@@ -354,4 +354,28 @@ impl Subscriber {
                 },
             )
     }
+
+    #[wasm_bindgen(catch)]
+    pub fn fetch_state(&self) -> Result<Array> {
+        self.subscriber
+            .borrow_mut()
+            .fetch_state()
+            .map_or_else(
+                |err| Err(JsValue::from_str(&err.to_string())),
+                |state_list| {
+                    Ok(state_list.into_iter()
+                        .map(|(pk, cursor)| JsValue::from(UserState::new(pk, cursor.into())))
+                        .collect()
+                    )
+                }
+            )
+    }
+
+    #[wasm_bindgen(catch)]
+    pub fn reset_state(self) -> Result<()> {
+        self.subscriber
+            .borrow_mut()
+            .reset_state()
+            .map_or_else(|err| Err(JsValue::from_str(&err.to_string())), Ok)
+    }
 }

--- a/bindings/wasm/src/types/mod.rs
+++ b/bindings/wasm/src/types/mod.rs
@@ -3,17 +3,20 @@ use core::{
     convert::TryFrom,
 };
 use iota_streams::{
-    app::transport::tangle::client::{
-        iota_client::{
-            bee_rest_api::types::{
-                dtos::LedgerInclusionStateDto,
-                responses::MessageMetadataResponse as ApiMessageMetadata,
+    app::{
+        message::Cursor as ApiCursor,
+        transport::tangle::client::{
+            iota_client::{
+                bee_rest_api::types::{
+                    dtos::LedgerInclusionStateDto,
+                    responses::MessageMetadataResponse as ApiMessageMetadata,
+                },
+                MilestoneResponse as ApiMilestoneResponse,
             },
-            MilestoneResponse as ApiMilestoneResponse,
-        },
-        Client,
-        Details as ApiDetails,
-        SendOptions as ApiSendOptions,
+            Client,
+            Details as ApiDetails,
+            SendOptions as ApiSendOptions,
+        }
     },
     app_channels::api::tangle::{
         Address as ApiAddress,
@@ -218,6 +221,52 @@ pub struct UserResponse {
 pub struct NextMsgId {
     pk: String,
     msgid: Address,
+}
+
+#[wasm_bindgen]
+pub struct UserState {
+    pk: String,
+    cursor: Cursor,
+}
+
+#[wasm_bindgen]
+pub struct Cursor {
+    link: Address,
+    seq_no: u32,
+    branch_no: u32,
+}
+
+impl From<ApiCursor<ApiAddress>> for Cursor {
+    fn from(cursor: ApiCursor<ApiAddress>) -> Self {
+        Cursor {
+            link: Address::from_string(cursor.link.to_string()),
+            seq_no: cursor.seq_no,
+            branch_no: cursor.branch_no
+        }
+    }
+}
+
+#[wasm_bindgen]
+impl UserState {
+    pub fn new(pk: String, cursor: Cursor) -> Self {
+        UserState { pk, cursor }
+    }
+
+    pub fn get_pk(&self) -> String {
+        self.pk.clone()
+    }
+
+    pub fn get_link(&self) -> Address {
+        self.cursor.link.copy()
+    }
+
+    pub fn get_seq_no(&self) -> u32 {
+        self.cursor.seq_no
+    }
+
+    pub fn get_branch_no(&self) -> u32 {
+        self.cursor.branch_no
+    }
 }
 
 #[wasm_bindgen]

--- a/bindings/wasm/src/types/mod.rs
+++ b/bindings/wasm/src/types/mod.rs
@@ -16,7 +16,7 @@ use iota_streams::{
             Client,
             Details as ApiDetails,
             SendOptions as ApiSendOptions,
-        }
+        },
     },
     app_channels::api::tangle::{
         Address as ApiAddress,
@@ -241,7 +241,7 @@ impl From<ApiCursor<ApiAddress>> for Cursor {
         Cursor {
             link: Address::from_string(cursor.link.to_string()),
             seq_no: cursor.seq_no,
-            branch_no: cursor.branch_no
+            branch_no: cursor.branch_no,
         }
     }
 }

--- a/docs/libraries/wasm/api_reference.md
+++ b/docs/libraries/wasm/api_reference.md
@@ -76,6 +76,12 @@ Retrieve the Author public key.
 | --------------- | ------------------- | ------------------------- |
 **Returns:** The Author public key in hex representation.
 
+#### fetch_state(): Array<[UserState](#UserState)>
+Retrieve the currently known publisher states for the channel.
+
+| Param           | Type                | Description               |
+| --------------- | ------------------- | ------------------------- |
+**Returns:** An array of user state objects representing the currently known state of all publishers in the channel.
 
 
 #### The following functions require author.clone() to use, as they consume the instance 
@@ -293,6 +299,13 @@ Unregister a subscriber instance from a channel.
 | Param           | Type                | Description               |
 | --------------- | ------------------- | ------------------------- |
 
+#### fetch_state(): Array<[UserState](#UserState)>
+Retrieve the currently known publisher states for the channel.
+
+| Param           | Type                | Description               |
+| --------------- | ------------------- | ------------------------- |
+**Returns:** An array of user state objects representing the currently known state of all publishers in the channel.
+
 #### The following functions require subscriber.clone() to use, as they consume the instance 
 #### _async -_ send_subscribe(link): [UserResponse](#UserResponse)
 Send a subscription message attached to an announcement message link. 
@@ -410,6 +423,12 @@ Store a Pre Shared Key (Psk) and retrieve the Pre Shared Key Id (PskId) for use 
 
 **Returns:** A PskId String representing the Psk in store.
 
+#### reset_state()
+Reset the mapping of known publisher states for the channel for retrieval of messages from scratch.
+
+| Param           | Type                | Description               |
+| --------------- | ------------------- | ------------------------- |
+
 ## Types
 Generic Types and Primitives used in Wasm API:
 - [Client](#Client)
@@ -418,6 +437,8 @@ Generic Types and Primitives used in Wasm API:
 - [Address](#Address)
 - [Message](#Message)
 - [NextMsgId](#NextMsgId)
+- [Cursor](#Cursor)
+- [UserState](#UserState)
 
 ### Client 
 Transport client for interacting with an Iota node.
@@ -655,3 +676,40 @@ Fetch Public Keys in string formatting
 | Param     | Type                  | Description                                  |
 | --------- | --------------------- | -------------------------------------------- |
 **Returns:** Array of Public Keys in string formatting
+
+### Cursor
+The publishing state of a particular publisher (The latest sequenced message known for that publisher). This includes:
+- The latest published message link
+- The sequence state number of the publisher
+- A branch number for that latest posted message 
+
+### UserState
+A wrapper around a publisher state. Includes the public key and [cursor](#Cursor) of the publisher
+
+#### get_pk()
+Get the public key of the user from the state
+
+| Param     | Type                  | Description                                  |
+| --------- | --------------------- | -------------------------------------------- |
+**Returns:** Public Key of publisher in hex formatting
+
+#### get_link() 
+Get the link from the internal cursor object 
+
+| Param     | Type                  | Description                                  |
+| --------- | --------------------- | -------------------------------------------- |
+**Returns:** The latest published message link 
+
+#### get_seq_no()
+Get the sequence state number from the internal cursor object 
+
+| Param     | Type                  | Description                                  |
+| --------- | --------------------- | -------------------------------------------- |
+**Returns:** The latest sequence state number of the publisher 
+
+#### get_seq_no()
+Get the branch state number from the internal cursor object
+
+| Param     | Type                  | Description                                  |
+| --------- | --------------------- | -------------------------------------------- |
+**Returns:** The latest branch state number of the publisher 

--- a/docs/libraries/wasm/api_reference.md
+++ b/docs/libraries/wasm/api_reference.md
@@ -707,7 +707,7 @@ Get the sequence state number from the internal cursor object
 | --------- | --------------------- | -------------------------------------------- |
 **Returns:** The latest sequence state number of the publisher 
 
-#### get_seq_no()
+#### get_branch_no()
 Get the branch state number from the internal cursor object
 
 | Param     | Type                  | Description                                  |

--- a/examples/src/branching/multi_branch.rs
+++ b/examples/src/branching/multi_branch.rs
@@ -7,7 +7,7 @@ use iota_streams::{
         Transport,
     },
     core::{
-        prelude::Rc,
+        prelude::{HashMap, Rc},
         print,
         println,
         try_or,
@@ -72,6 +72,9 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_type: ChannelTyp
             BranchingFlagMismatch(String::from("A"))
         )?;
     }
+
+    // Fetch state of subscriber for comparison after reset
+    let sub_a_start_state: HashMap<_,_> = subscriberA.fetch_state()?.into_iter().collect();
 
     println!("\nSubscribe A");
     let subscribeA_link = {
@@ -339,6 +342,19 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_type: ChannelTyp
         println!("Found {} messages", msgs.len());
         println!("  SubscriberB: {}", subscriberA);
     }
+
+    subscriberA.reset_state()?;
+    let new_state: HashMap<_,_>  = subscriberA.fetch_state()?.into_iter().collect();
+
+    println!("\nSubscriber A resetting state");
+    let mut matches = false;
+    for (old_pk, old_cursor) in sub_a_start_state.iter() {
+        if new_state.contains_key(old_pk) && new_state[old_pk].link == old_cursor.link {
+            matches = true
+        }
+        try_or!(matches, StateMismatch)?;
+    }
+    println!("Subscriber states matched");
 
     Ok(())
 }

--- a/iota-streams-app-channels/src/api/tangle/subscriber.rs
+++ b/iota-streams-app-channels/src/api/tangle/subscriber.rs
@@ -115,6 +115,12 @@ impl<Trans> Subscriber<Trans> {
         Ok(state)
     }
 
+    /// Resets the cursor state storage to allow a Subscriber to retrieve all messages in a channel
+    /// from scratch
+    pub fn reset_state(&mut self) -> Result<()> {
+        self.user.reset_state()
+    }
+
     /// Generate a vector containing the next sequenced message identifier for each publishing
     /// participant in the channel
     ///

--- a/iota-streams-app-channels/src/api/tangle/user.rs
+++ b/iota-streams-app-channels/src/api/tangle/user.rs
@@ -125,6 +125,13 @@ impl<Trans> User<Trans> {
         self.user.fetch_state()
     }
 
+    /// Resets the cursor state storage to allow a Subscriber to retrieve all messages in a channel
+    /// from scratch
+    /// [Subscriber]
+    pub fn reset_state(&mut self) -> Result<()> {
+        self.user.reset_state()
+    }
+
     /// Generate a vector containing the next sequenced message identifier for each publishing
     /// participant in the channel
     /// [Author, Subscriber]

--- a/iota-streams-app-channels/src/api/user.rs
+++ b/iota-streams-app-channels/src/api/user.rs
@@ -253,6 +253,23 @@ where
         Ok(())
     }
 
+    /// Reset link store and key store to original state
+    pub fn reset_state(&mut self) -> Result<()> {
+        match &self.appinst {
+            Some(appinst) => {
+                let mut pk_store = PKS::default();
+                for (pk, _cursor) in self.pk_store.iter() {
+                    pk_store.insert(*pk, Cursor::new_at(appinst.rel().clone(), 0, 2_u32))?;
+                }
+                self.pk_store = pk_store;
+
+                self.link_gen.reset(appinst.clone());
+                Ok(())
+            },
+            None => err(UserNotRegistered),
+        }
+    }
+
     /// Save spongos and info associated to the message link
     pub fn commit_wrapped(
         &mut self,

--- a/iota-streams-app-channels/src/api/user.rs
+++ b/iota-streams-app-channels/src/api/user.rs
@@ -265,7 +265,7 @@ where
 
                 self.link_gen.reset(appinst.clone());
                 Ok(())
-            },
+            }
             None => err(UserNotRegistered),
         }
     }

--- a/iota-streams-core/src/errors/error_messages.rs
+++ b/iota-streams-core/src/errors/error_messages.rs
@@ -164,6 +164,8 @@ pub enum Errors {
     SubscriberAccessMismatch(String),
     /// Expected Link does not match (expected: {0}, found {1})
     LinkMismatch(String, String),
+    /// States do not match
+    StateMismatch,
 
     //////////
     // Tests


### PR DESCRIPTION
# Description of change
Add `reset_state` function to subscribers to allow subscribers to fetch messages from scratch without restarting their instance. 

Example: 
```
subscriber.reset_state()?;
let msgs = subscriber.fetch_all_next_msgs();
```

Bindings and  docs have been updated as well. 

## Type of change
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested
New section in examples demonstrating usage in rust, c and wasm.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
