### PR TITLE
Re-enable some lints from app and app-channels

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -23,11 +23,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Install clippy with Nightly toolchain
+      - name: Install clippy with stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-07-05
+          toolchain: stable
           override: true
           components: clippy
       - uses: actions-rs/clippy-check@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 name = "iota-streams"
 version = "1.0.0"
-authors = ["Vlad Semenov <vlad.semenov@iota.org>", "Dyrell Chapman <dyrell.chapman@iota.org>", "Brord van Wierst <brord@iota.org>"]
+authors = ["Vlad Semenov <vlad.semenov@iota.org>", "Dyrell Chapman <dyrell.chapman@iota.org>", "Brord van Wierst <brord@iota.org>", "Arnau Orriols <arnau.orriols@iota.org"]
 edition = "2018"
 license = "Apache-2.0/MIT"
 readme = "README.md"

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -19,7 +19,7 @@ if(${SYNC_CLIENT})
   set(cargo_features "${cargo_features}sync-client")
 endif(${SYNC_CLIENT})
 
-message("NO_STD=${NO_STD} SYNC_CLIENT=${SYNC_CLIENT} STATIC=${STATIC}")
+message("NO_STD=${NO_STD} SYNC_CLIENT=${SYNC_CLIENT} STATIC=${STATIC} RELEASE=${RELEASE}")
 
 include_directories(include/)
 

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -4,8 +4,8 @@ project(iota_streams_c LANGUAGES C)
 include(FetchContent)
 
 option(NO_STD "Enable no_std build, without iota_client" OFF)
-option(SYNC_CLIENT "Enable sync transport via iota_client" OFF)
-option(STATIC "Build static library" ON)
+option(SYNC_CLIENT "Enable sync transport via iota_client" ON)
+option(STATIC "Build static library" OFF)
 option(RELEASE "Build release library (defaults to release)" ON)
 
 set(cargo_features "")

--- a/bindings/c/README.md
+++ b/bindings/c/README.md
@@ -7,6 +7,7 @@ Check out `CMakeLists.txt` and change the 3 options to your preference:
 - `NO_STD`: Enable no_std build, without iota_client (when ON, `SYNC_CLIENT` isnt supported)
 - `SYNC_CLIENT`: Enable sync transport via iota_client, otherwise it's going to be Bucket which can only be used for tests
 - `STATIC`: Build static library when ON, otherwise dynamic library
+- `RELEASE`: Build in release or debug mode (when ON, builds release, when OFF, build debug)
 
 Edit your author and subscriber seeds in `main.c`
 
@@ -18,8 +19,7 @@ A binary will be generated which you can run depending on your STATIC setting
 - ON:  `iota_streams_c_static`
 - OFF: `libiota_streams_c.so`(Unix), `iota_streams_c.dll`(Windows) and the executable `iota_streams_c`
 
-You can then run the static build or the dynamic executable. Keep in mind that by default the code points to a node on `http://localhost:14265`.
-If this node doesnt exist, we will exit with an error immediately.
+You can then run the static build or the dynamic executable. 
 
 You can set the following environment variables to change this dynamically:
 - `URL`: Change the node we use to send and receive messages (Accepts string)

--- a/bindings/c/src/api/auth.rs
+++ b/bindings/c/src/api/auth.rs
@@ -171,8 +171,10 @@ pub unsafe extern "C" fn auth_send_keyload(
             link_to.as_ref().map_or(Err::NullArgument, |link_to| {
                 psk_ids.as_ref().map_or(Err::NullArgument, |psk_ids| {
                     ke_pks.as_ref().map_or(Err::NullArgument, |ke_pks| {
-                        let identifiers: Vec<Identifier> = ke_pks.into_iter().map(|pk| (*pk).into()).collect();
-                        user.send_keyload(link_to, psk_ids, &identifiers.iter().collect())
+                        let pks = ke_pks.into_iter().copied().map(Into::<Identifier>::into);
+                        let psks = psk_ids.into_iter().copied().map(Into::<Identifier>::into);
+                        let identifiers: Vec<Identifier> = pks.chain(psks).collect();
+                        user.send_keyload(link_to, &identifiers)
                             .map_or(Err::OperationFailed, |response| {
                                 *r = response.into();
                                 Err::Ok

--- a/bindings/c/src/api/mod.rs
+++ b/bindings/c/src/api/mod.rs
@@ -368,7 +368,6 @@ impl MessageLinks {
         safe_drop_ptr(self.msg_link);
         safe_drop_ptr(self.seq_link);
     }
-
 }
 
 impl Default for MessageLinks {
@@ -394,8 +393,6 @@ pub unsafe extern "C" fn get_msg_link(msg_links: *const MessageLinks) -> *const 
 pub unsafe extern "C" fn get_seq_link(msg_links: *const MessageLinks) -> *const Address {
     msg_links.as_ref().map_or(null(), |links| links.seq_link)
 }
-
-
 
 #[repr(C)]
 pub struct Buffer {

--- a/bindings/c/src/api/mod.rs
+++ b/bindings/c/src/api/mod.rs
@@ -521,7 +521,7 @@ pub extern "C" fn drop_payloads(payloads: PacketPayloads) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn drop_str(string: *mut c_char) {
+pub unsafe extern "C" fn drop_str(string: *const c_char) {
     CString::from_raw(string as *mut c_char);
 }
 

--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -23,5 +23,5 @@ npm run build:nodejs
 ```
 
 ```bash
-npm run example:node
+npm run example:nodejs
 ```

--- a/bindings/wasm/examples/node.js
+++ b/bindings/wasm/examples/node.js
@@ -1,4 +1,4 @@
-const streams = require("../node/streams_wasm");
+const streams = require("../node/iota_streams_wasm");
 const fetch = require("node-fetch");
 
 global.fetch = fetch;

--- a/bindings/wasm/examples/node.ts
+++ b/bindings/wasm/examples/node.ts
@@ -1,4 +1,4 @@
-import * as streams from '../node/streams_wasm';
+import * as streams from '../node/iota_streams_wasm';
 
 import * as fetch from 'node-fetch';
 

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -17,7 +17,7 @@
     "prepublishOnly": "npm run build",
     "test": "mocha",
     "serve": "webpack-dev-server",
-    "example:node": "node examples/node.js"
+    "example:nodejs": "node examples/node.js"
   },
   "contributors": [
     "huhn511 <huhn.dev@gmail.com>"

--- a/bindings/wasm/src/author/authorw.rs
+++ b/bindings/wasm/src/author/authorw.rs
@@ -162,15 +162,16 @@ impl Author {
 
     #[wasm_bindgen(catch)]
     pub async fn send_keyload(self, link: Address, psk_ids: PskIdsW, sig_pks: PublicKeysW) -> Result<UserResponse> {
-        let pks: Vec<Identifier> = sig_pks.pks.iter().map(|pk| (*pk).into()).collect();
+        let pks = sig_pks.pks.into_iter().map(Into::<Identifier>::into);
+        let psks = psk_ids.ids.into_iter().map(Into::<Identifier>::into);
+        let identifiers: Vec<Identifier> = pks.chain(psks).collect();
         self.author
             .borrow_mut()
             .send_keyload(
                 &link
                     .try_into()
                     .map_or_else(|_err| ApiAddress::default(), |addr: ApiAddress| addr),
-                &psk_ids.ids,
-                &pks.iter().collect(),
+                &identifiers,
             )
             .await
             .map_or_else(

--- a/bindings/wasm/src/types/mod.rs
+++ b/bindings/wasm/src/types/mod.rs
@@ -1,6 +1,7 @@
 use core::{
     cell::RefCell,
     convert::TryFrom,
+    str::FromStr,
 };
 use iota_streams::{
     app::{
@@ -160,7 +161,7 @@ pub type ClientWrap = Rc<RefCell<Client>>;
 impl TryFrom<Address> for ApiAddress {
     type Error = JsValue;
     fn try_from(addr: Address) -> Result<Self> {
-        ApiAddress::from_str(&addr.addr_id, &addr.msg_id).map_err(|_err| JsValue::from_str("bad address"))
+        ApiAddress::from_str(&addr.to_string()).map_err(|_err| JsValue::from_str("bad address"))
     }
 }
 

--- a/documentation/docs/libraries/wasm/getting_started.md
+++ b/documentation/docs/libraries/wasm/getting_started.md
@@ -11,7 +11,7 @@ To build the library, first make sure you're in the wasm directory:
 
 For building the nodejs compatible api, run:
 ```bash
-npm run build:node  <- Builds to node/iota_streams_wasm
+npm run build:nodejs  <- Builds to node/iota_streams_wasm
 ```
 
 And for building the web compatible api, run:

--- a/examples/src/branching/multi_branch.rs
+++ b/examples/src/branching/multi_branch.rs
@@ -39,7 +39,7 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_type: ChannelTyp
     println!("\nAnnounce Channel");
     let announcement_link = {
         let msg = author.send_announce()?;
-        println!("  msg => <{}> {:?}", msg.msgid, msg);
+        println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         print!("  Author     : {}", author);
         msg
     };
@@ -89,7 +89,7 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_type: ChannelTyp
     println!("\nSubscribe A");
     let subscribeA_link = {
         let msg = subscriberA.send_subscribe(&announcement_link)?;
-        println!("  msg => <{}> {:?}", msg.msgid, msg);
+        println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         print!("  SubscriberA: {}", subscriberA);
         msg
     };
@@ -104,8 +104,8 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_type: ChannelTyp
     let (keyload_link, keyload_seq) = {
         let (msg, seq) = author.send_keyload_for_everyone(&announcement_link)?;
         let seq = seq.unwrap();
-        println!("  msg => <{}> {:?}", msg.msgid, msg);
-        println!("  seq => <{}> {:?}", seq.msgid, seq);
+        println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
+        println!("  seq => <{}> <{:x}>", seq.msgid, seq.to_msg_index());
         print!("  Author     : {}", author);
         (msg, seq)
     };
@@ -132,8 +132,8 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_type: ChannelTyp
     let (tagged_packet_link, tagged_packet_seq) = {
         let (msg, seq) = subscriberA.send_tagged_packet(&keyload_link, &public_payload, &masked_payload)?;
         let seq = seq.unwrap();
-        println!("  msg => <{}> {:?}", msg.msgid, msg);
-        println!("  seq => <{}> {:?}", seq.msgid, seq);
+        println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
+        println!("  seq => <{}> <{:x}>", seq.msgid, seq.to_msg_index());
         print!("  SubscriberA: {}", subscriberA);
         (msg, seq)
     };
@@ -175,8 +175,8 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_type: ChannelTyp
     let (_signed_packet_link, signed_packet_seq) = {
         let (msg, seq) = author.send_signed_packet(&tagged_packet_link, &public_payload, &masked_payload)?;
         let seq = seq.unwrap();
-        println!("  msg => <{}> {:?}", msg.msgid, msg);
-        println!("  seq => <{}> {:?}", seq.msgid, seq);
+        println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
+        println!("  seq => <{}> <{:x}>", seq.msgid, seq.to_msg_index());
         print!("  Author     : {}", author);
         (msg, seq)
     };
@@ -199,7 +199,7 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_type: ChannelTyp
     println!("\nSubscribe B");
     let subscribeB_link = {
         let msg = subscriberB.send_subscribe(&announcement_link)?;
-        println!("  msg => <{}> {:?}", msg.msgid, msg);
+        println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         print!("  SubscriberB: {}", subscriberB);
         msg
     };
@@ -214,8 +214,8 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_type: ChannelTyp
     let (keyload_link, keyload_seq) = {
         let (msg, seq) = author.send_keyload_for_everyone(&announcement_link)?;
         let seq = seq.unwrap();
-        println!("  msg => <{}> {:?}", msg.msgid, msg);
-        println!("  seq => <{}> {:?}", seq.msgid, seq);
+        println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
+        println!("  seq => <{}> <{:x}>", seq.msgid, seq.to_msg_index());
         print!("  Author     : {}", author);
         (msg, seq)
     };
@@ -240,8 +240,8 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_type: ChannelTyp
     let (tagged_packet_link, tagged_packet_seq) = {
         let (msg, seq) = subscriberA.send_tagged_packet(&keyload_link, &public_payload, &masked_payload)?;
         let seq = seq.unwrap();
-        println!("  msg => <{}> {:?}", msg.msgid, msg);
-        println!("  seq => <{}> {:?}", seq.msgid, seq);
+        println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
+        println!("  seq => <{}> <{:x}>", seq.msgid, seq.to_msg_index());
         print!("  SubscriberA: {}", subscriberA);
         (msg, seq)
     };
@@ -279,8 +279,8 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_type: ChannelTyp
     let (tagged_packet_link, tagged_packet_seq) = {
         let (msg, seq) = subscriberB.send_tagged_packet(&tagged_packet_link, &public_payload, &masked_payload)?;
         let seq = seq.unwrap();
-        println!("  msg => <{}> {:?}", msg.msgid, msg);
-        println!("  seq => <{}> {:?}", seq.msgid, seq);
+        println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
+        println!("  seq => <{}> <{:x}>", seq.msgid, seq.to_msg_index());
         print!("  SubscriberB: {}", subscriberB);
         (msg, seq)
     };
@@ -360,8 +360,8 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_type: ChannelTyp
     let (signed_packet_link, signed_packet_seq) = {
         let (msg, seq) = author.send_signed_packet(&tagged_packet_seq, &public_payload, &masked_payload)?;
         let seq = seq.unwrap();
-        println!("  msg => <{}> {:?}", msg.msgid, msg);
-        println!("  seq => <{}> {:?}", seq.msgid, seq);
+        println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
+        println!("  seq => <{}> <{:x}>", seq.msgid, seq.to_msg_index());
         print!("  Author     : {}", author);
         (msg, seq)
     };

--- a/examples/src/branching/recovery.rs
+++ b/examples/src/branching/recovery.rs
@@ -34,7 +34,7 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_type: ChannelTyp
     println!("\nAnnounce Channel");
     let announcement_link = {
         let msg = author.send_announce()?;
-        println!("  msg => <{}> {}", msg.msgid, msg);
+        println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         msg
     };
     println!("  Author channel address: {}", author.channel_address().unwrap());
@@ -45,7 +45,7 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_type: ChannelTyp
     println!("\nSubscribe A");
     let subscribeA_link = {
         let msg = subscriberA.send_subscribe(&announcement_link)?;
-        println!("  msg => <{}> {}", msg.msgid, msg);
+        println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         msg
     };
 
@@ -55,7 +55,7 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_type: ChannelTyp
     println!("\nShare keyload");
     let mut previous_msg_link = {
         let (msg, seq) = author.send_keyload_for_everyone(&announcement_link)?;
-        println!("  msg => <{}> {}", msg.msgid, msg);
+        println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         panic_if_not(seq.is_none());
         msg
     };
@@ -64,7 +64,7 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_type: ChannelTyp
         println!("Signed packet {} - Author", i);
         previous_msg_link = {
             let (msg, seq) = author.send_signed_packet(&previous_msg_link, &public_payload, &masked_payload)?;
-            println!("  msg => <{}> {}", msg.msgid, msg);
+            println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
             panic_if_not(seq.is_none());
             msg
         };
@@ -79,7 +79,7 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_type: ChannelTyp
         println!("Tagged packet {} - SubscriberA", i);
         previous_msg_link = {
             let (msg, seq) = subscriberA.send_tagged_packet(&previous_msg_link, &public_payload, &masked_payload)?;
-            println!("  msg => <{}> {}", msg.msgid, msg);
+            println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
             panic_if_not(seq.is_none());
             msg
         };
@@ -112,7 +112,7 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_type: ChannelTyp
 
     println!("States match...\nSending next sequenced message...");
     let (last_msg, _seq) = new_author.send_signed_packet(latest_link, &public_payload, &masked_payload)?;
-    println!("  msg => <{}> {}", last_msg.msgid, last_msg);
+    println!("  msg => <{}> <{:x}>", last_msg.msgid, last_msg.to_msg_index());
 
     // Wait a second for message to propagate
     sleep(Duration::from_secs(1));

--- a/examples/src/branching/single_branch.rs
+++ b/examples/src/branching/single_branch.rs
@@ -40,7 +40,7 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_impl: ChannelTyp
     println!("\nAnnounce Channel");
     let announcement_link = {
         let msg = author.send_announce()?;
-        println!("  msg => <{}> {:?}", msg.msgid, msg);
+        println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         print!("  Author     : {}", author);
         msg
     };
@@ -91,7 +91,7 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_impl: ChannelTyp
     println!("\nSubscribe A");
     let subscribeA_link = {
         let msg = subscriberA.send_subscribe(&announcement_link)?;
-        println!("  msg => <{}> {:?}", msg.msgid, msg);
+        println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         print!("  SubscriberA: {}", subscriberA);
         msg
     };
@@ -105,7 +105,7 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_impl: ChannelTyp
     println!("\nSubscribe B");
     let subscribeB_link = {
         let msg = subscriberB.send_subscribe(&announcement_link)?;
-        println!("  msg => <{}> {:?}", msg.msgid, msg);
+        println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         print!("  SubscriberB: {}", subscriberB);
         msg
     };
@@ -119,7 +119,7 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_impl: ChannelTyp
     println!("\nShare keyload for everyone [SubscriberA, SubscriberB, PSK]");
     let previous_msg_link = {
         let (msg, seq) = author.send_keyload_for_everyone(&announcement_link)?;
-        println!("  msg => <{}> {:?}", msg.msgid, msg);
+        println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         panic_if_not(seq.is_none());
         print!("  Author     : {}", author);
         msg
@@ -138,7 +138,7 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_impl: ChannelTyp
     println!("\nSigned packet");
     let previous_msg_link = {
         let (msg, seq) = author.send_signed_packet(&previous_msg_link, &public_payload, &masked_payload)?;
-        println!("  msg => <{}> {:?}", msg.msgid, msg);
+        println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         panic_if_not(seq.is_none());
         print!("  Author     : {}", author);
         msg
@@ -166,7 +166,7 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_impl: ChannelTyp
     println!("\nTagged packet 1 - SubscriberA");
     let previous_msg_link = {
         let (msg, seq) = subscriberA.send_tagged_packet(&previous_msg_link, &public_payload, &masked_payload)?;
-        println!("  msg => <{}> {:?}", msg.msgid, msg);
+        println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         panic_if_not(seq.is_none());
         print!("  SubscriberA: {}", subscriberA);
         msg
@@ -200,7 +200,7 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_impl: ChannelTyp
     println!("\nTagged packet 2 - SubscriberA");
     let previous_msg_link = {
         let (msg, seq) = subscriberA.send_tagged_packet(&previous_msg_link, &public_payload, &masked_payload)?;
-        println!("  msg => <{}> {:?}", msg.msgid, msg);
+        println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         panic_if_not(seq.is_none());
         print!("  SubscriberA: {}", subscriberA);
         msg
@@ -209,7 +209,7 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_impl: ChannelTyp
     println!("\nTagged packet 3 - SubscriberA");
     let previous_msg_link = {
         let (msg, seq) = subscriberA.send_tagged_packet(&previous_msg_link, &public_payload, &masked_payload)?;
-        println!("  msg => <{}> {:?}", msg.msgid, msg);
+        println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         panic_if_not(seq.is_none());
         print!("  SubscriberA: {}", subscriberA);
         msg
@@ -223,7 +223,7 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_impl: ChannelTyp
     println!("\nTagged packet 4 - SubscriberB");
     let previous_msg_link = {
         let (msg, seq) = subscriberB.send_tagged_packet(&previous_msg_link, &public_payload, &masked_payload)?;
-        println!("  msg => <{}> {:?}", msg.msgid, msg);
+        println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         panic_if_not(seq.is_none());
         print!("  SubscriberB: {}", subscriberB);
         msg
@@ -300,7 +300,7 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_impl: ChannelTyp
     println!("\nSigned packet");
     let signed_packet_link = {
         let (msg, seq) = author.send_signed_packet(&previous_msg_link, &public_payload, &masked_payload)?;
-        println!("  msg => <{}> {:?}", msg.msgid, msg);
+        println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         panic_if_not(seq.is_none());
         print!("  Author     : {}", author);
         msg

--- a/iota-streams-app-channels/src/api/key_store.rs
+++ b/iota-streams-app-channels/src/api/key_store.rs
@@ -15,7 +15,9 @@ use iota_streams_core::{
 use iota_streams_core_edsig::key_exchange::x25519;
 
 pub trait KeyStore<Info, F: PRP>: Default {
-    fn filter(&self, pks: &[&Identifier]) -> Vec<(&Identifier, Vec<u8>)>;
+    fn filter<'a, I>(&self, pks: I) -> Vec<(&Identifier, Vec<u8>)>
+    where
+        I: IntoIterator<Item = &'a Identifier>;
 
     /// Retrieve the sequence state for a given publisher
     fn get(&self, id: &Identifier) -> Option<&Info>;
@@ -54,8 +56,11 @@ impl<Info> Default for KeyMap<Info> {
 }
 
 impl<Info, F: PRP> KeyStore<Info, F> for KeyMap<Info> {
-    fn filter(&self, ids: &[&Identifier]) -> Vec<(&Identifier, Vec<u8>)> {
-        ids.iter()
+    fn filter<'a, I>(&self, ids: I) -> Vec<(&Identifier, Vec<u8>)>
+    where
+        I: IntoIterator<Item = &'a Identifier>,
+    {
+        ids.into_iter()
             .filter_map(|id| match &id {
                 Identifier::EdPubKey(_id) => self
                     .ke_pks
@@ -64,8 +69,8 @@ impl<Info, F: PRP> KeyStore<Info, F> for KeyMap<Info> {
                 Identifier::PskId(_id) => self
                     .psks
                     .get_key_value(id)
-                    .filter(|(_, (x, _))| x.is_some())
-                    .map(|(e, (x, _))| (e, x.unwrap().to_vec())),
+                    .map(|(e, (x, _))| x.map(|xx| (e, xx.to_vec())))
+                    .flatten(),
             })
             .collect()
     }

--- a/iota-streams-app-channels/src/api/key_store.rs
+++ b/iota-streams-app-channels/src/api/key_store.rs
@@ -15,7 +15,7 @@ use iota_streams_core::{
 use iota_streams_core_edsig::key_exchange::x25519;
 
 pub trait KeyStore<Info, F: PRP>: Default {
-    fn filter<'a, I>(&self, pks: I) -> Vec<(&Identifier, Vec<u8>)>
+    fn filter<'a, I>(&self, ids: I) -> Vec<(&Identifier, Vec<u8>)>
     where
         I: IntoIterator<Item = &'a Identifier>;
 

--- a/iota-streams-app-channels/src/api/mod.rs
+++ b/iota-streams-app-channels/src/api/mod.rs
@@ -5,7 +5,6 @@ pub mod key_store;
 /// type_complexity to be determined in future issue
 
 /// Base level api for user implementation
-#[allow(clippy::type_complexity)]
 pub mod user;
 
 /// Tangle-specific Channel API.

--- a/iota-streams-app-channels/src/api/mod.rs
+++ b/iota-streams-app-channels/src/api/mod.rs
@@ -5,7 +5,7 @@ pub mod key_store;
 /// type_complexity to be determined in future issue
 
 /// Base level api for user implementation
-#[allow(clippy::ptr_arg, clippy::type_complexity)]
+#[allow(clippy::type_complexity)]
 pub mod user;
 
 /// Tangle-specific Channel API.

--- a/iota-streams-app-channels/src/api/tangle/author.rs
+++ b/iota-streams-app-channels/src/api/tangle/author.rs
@@ -171,15 +171,12 @@ impl<Trans: Transport + Clone> Author<Trans> {
     ///
     ///  # Arguments
     ///  * `link_to` - Address of the message the keyload will be attached to
-    ///  * `psk_ids` - Vector of Pre-shared key ids to be included in message
-    ///  * `ke_pks`  - Vector of Public Keys to be included in message
-    pub fn send_keyload(
-        &mut self,
-        link_to: &Address,
-        psk_ids: &PskIds,
-        ke_pks: &Vec<&Identifier>,
-    ) -> Result<(Address, Option<Address>)> {
-        self.user.send_keyload(link_to, psk_ids, ke_pks)
+    ///  * `keys`  - Iterable of [`Identifier`] to be included in message
+    pub fn send_keyload<'a, I>(&mut self, link_to: &Address, keys: I) -> Result<(Address, Option<Address>)>
+    where
+        I: IntoIterator<Item = &'a Identifier>,
+    {
+        self.user.send_keyload(link_to, keys)
     }
 
     /// Create and send keyload for all subscribed subscribers.
@@ -344,15 +341,12 @@ impl<Trans: Transport + Clone> Author<Trans> {
     ///
     ///  # Arguments
     ///  * `link_to` - Address of the message the keyload will be attached to
-    ///  * `psk_ids` - Vector of Pre-shared key ids to be included in message
-    ///  * `ke_pks`  - Vector of Public Keys to be included in message
-    pub async fn send_keyload(
-        &mut self,
-        link_to: &Address,
-        psk_ids: &PskIds,
-        ke_pks: &[&Identifier],
-    ) -> Result<(Address, Option<Address>)> {
-        self.user.send_keyload(link_to, psk_ids, ke_pks).await
+    ///  * `keys`  - Iterable of [`Identifier`] to be included in message
+    pub async fn send_keyload<'a, I>(&mut self, link_to: &Address, keys: I) -> Result<(Address, Option<Address>)>
+    where
+        I: IntoIterator<Item = &'a Identifier>,
+    {
+        self.user.send_keyload(link_to, keys).await
     }
 
     /// Create and send keyload for all subscribed subscribers.

--- a/iota-streams-app-channels/src/api/tangle/author.rs
+++ b/iota-streams-app-channels/src/api/tangle/author.rs
@@ -350,7 +350,7 @@ impl<Trans: Transport + Clone> Author<Trans> {
         &mut self,
         link_to: &Address,
         psk_ids: &PskIds,
-        ke_pks: &Vec<&Identifier>,
+        ke_pks: &[&Identifier],
     ) -> Result<(Address, Option<Address>)> {
         self.user.send_keyload(link_to, psk_ids, ke_pks).await
     }

--- a/iota-streams-app-channels/src/api/tangle/mod.rs
+++ b/iota-streams-app-channels/src/api/tangle/mod.rs
@@ -87,8 +87,12 @@ impl<T> Transport for T where T: transport::Transport<Address, Message> + Clone 
 mod msginfo;
 pub use msginfo::MsgInfo;
 
-/// Message body returned as part of handle message routine.
+// SignedPacket is 240 bytes in stack (192 + 24 + 24), which means 5 times more than
+// the next biggest variant, TaggedPacket (48), and the impossibility of inlining.
+// Boxing PublicKey is most probably a net performance improvement. However,
+// a profile must validate it's hot enough to justify the ergonomic drawback.
 #[allow(clippy::large_enum_variant)]
+/// Message body returned as part of handle message routine.
 pub enum MessageContent {
     Announce,
     Keyload,

--- a/iota-streams-app-channels/src/api/tangle/mod.rs
+++ b/iota-streams-app-channels/src/api/tangle/mod.rs
@@ -86,9 +86,10 @@ mod msginfo;
 pub use msginfo::MsgInfo;
 
 // SignedPacket is 240 bytes in stack (192 + 24 + 24), which means 5 times more than
-// the next biggest variant, TaggedPacket (48), and the impossibility of inlining.
-// Boxing PublicKey is most probably a net performance improvement. However,
-// a profile must validate it's hot enough to justify the ergonomic drawback.
+// the next biggest variant (TaggedPacket, 48 bytes), and the impossibility of inlining.
+// Boxing PublicKey would usually be a net performance improvement if SignedPacket wasn't frequent.
+// However, chances are it is the most frequent variant, therefore a profile must confirm there's
+// enough performance improvement to justify the ergonomic drawback of re-enabling this lint
 #[allow(clippy::large_enum_variant)]
 /// Message body returned as part of handle message routine.
 pub enum MessageContent {

--- a/iota-streams-app-channels/src/api/tangle/mod.rs
+++ b/iota-streams-app-channels/src/api/tangle/mod.rs
@@ -144,12 +144,10 @@ pub type UnwrappedMessage = message::GenericMessage<Address, MessageContent>;
 /// Generic binary message type for sequence handling
 pub type BinaryMessage = message::GenericMessage<Address, BinaryBody<DefaultF>>;
 
-#[allow(clippy::ptr_arg)]
 mod user;
 /// User object storing the Auth/Sub implementation as well as the transport instance
 pub use user::User;
 
-#[allow(clippy::ptr_arg)]
 mod author;
 /// Tangle-specific Channel Author type.
 pub use author::Author;

--- a/iota-streams-app-channels/src/api/tangle/mod.rs
+++ b/iota-streams-app-channels/src/api/tangle/mod.rs
@@ -57,8 +57,6 @@ pub type WrappedMessage = message::WrappedMessage<DefaultF, Address>;
 pub type WrapState = message::WrapState<DefaultF, Address>;
 /// Wrapper for optional sequence message and state
 pub type WrappedSequence = super::user::WrappedSequence<DefaultF, Address>;
-/// Wrapped sequencing information with optional WrapState
-pub type WrapStateSequence = super::user::WrapStateSequence<DefaultF, Address>;
 /// Ed25519 Public Key
 pub type PublicKey = ed25519::PublicKey;
 

--- a/iota-streams-app-channels/src/api/tangle/test.rs
+++ b/iota-streams-app-channels/src/api/tangle/test.rs
@@ -1,6 +1,5 @@
 #![allow(non_snake_case)]
 use crate::api::tangle::{
-    Address,
     Author,
     Subscriber,
 };
@@ -33,12 +32,10 @@ pub fn example<T: Transport + Clone>(transport: T) -> Result<()> {
     let masked_payload = Bytes("MASKEDPAYLOAD".as_bytes().to_vec());
 
     println!("announce");
-    let (announcement_address, announcement_tag) = {
-        let msg = &author.send_announce()?;
-        println!("  {}", msg);
-        (msg.appinst.to_string(), msg.msgid.to_string())
-    };
-    let announcement_link = Address::from_str(&announcement_address, &announcement_tag).unwrap();
+    let msg = &author.send_announce()?;
+    let announcement_str = msg.to_string();
+    println!("  {}", announcement_str);
+    let announcement_link = announcement_str.parse().unwrap();
 
     {
         subscriberA.receive_announcement(&announcement_link)?;
@@ -149,12 +146,10 @@ pub async fn example<T: Transport + Clone>(transport: T) -> Result<()> where
     let masked_payload = Bytes("MASKEDPAYLOAD".as_bytes().to_vec());
 
     println!("announce");
-    let (announcement_address, announcement_tag) = {
-        let msg = &author.send_announce().await?;
-        println!("  {}", msg);
-        (msg.appinst.to_string(), msg.msgid.to_string())
-    };
-    let announcement_link = Address::from_str(&announcement_address, &announcement_tag).unwrap();
+    let msg = &author.send_announce().await?;
+    let announcement_str = msg.to_string();
+    println!("  {}", announcement_str);
+    let announcement_link = announcement_str.parse().unwrap();
 
     {
         subscriberA.receive_announcement(&announcement_link).await?;

--- a/iota-streams-app-channels/src/api/tangle/user.rs
+++ b/iota-streams-app-channels/src/api/tangle/user.rs
@@ -284,15 +284,12 @@ impl<Trans: Transport + Clone> User<Trans> {
     ///
     ///  # Arguments
     ///  * `link_to` - Address of the message the keyload will be attached to
-    ///  * `psk_ids` - Vector of Pre-shared key ids to be included in message
-    ///  * `ke_pks`  - Vector of Public Keys to be included in message
-    pub fn send_keyload(
-        &mut self,
-        link_to: &Address,
-        psk_ids: &PskIds,
-        ke_pks: &Vec<&Identifier>,
-    ) -> Result<(Address, Option<Address>)> {
-        let msg = self.user.share_keyload(link_to, psk_ids, ke_pks)?;
+    ///  * `keys`  - Iterable of [`Identifier`] to be included in message
+    pub fn send_keyload<'a, I>(&mut self, link_to: &Address, keys: I) -> Result<(Address, Option<Address>)>
+    where
+        I: IntoIterator<Item = &'a Identifier>,
+    {
+        let msg = self.user.share_keyload(link_to, keys)?;
         self.send_message_sequenced(msg, link_to.rel(), MsgInfo::Keyload)
     }
 
@@ -630,15 +627,12 @@ impl<Trans: Transport + Clone> User<Trans> {
     ///
     ///  # Arguments
     ///  * `link_to` - Address of the message the keyload will be attached to
-    ///  * `psk_ids` - Vector of Pre-shared key ids to be included in message
-    ///  * `ke_pks`  - Vector of Public Keys to be included in message
-    pub async fn send_keyload(
-        &mut self,
-        link_to: &Address,
-        psk_ids: &PskIds,
-        ke_pks: &[&Identifier],
-    ) -> Result<(Address, Option<Address>)> {
-        let msg = self.user.share_keyload(link_to, psk_ids, ke_pks)?;
+    ///  * `keys`  - Iterable of [`Identifier`] to be included in message
+    pub async fn send_keyload<'a, I>(&mut self, link_to: &Address, keys: I) -> Result<(Address, Option<Address>)>
+    where
+        I: IntoIterator<Item = &'a Identifier>,
+    {
+        let msg = self.user.share_keyload(link_to, keys)?;
         self.send_message_sequenced(msg, link_to.rel(), MsgInfo::Keyload).await
     }
 

--- a/iota-streams-app-channels/src/api/tangle/user.rs
+++ b/iota-streams-app-channels/src/api/tangle/user.rs
@@ -636,7 +636,7 @@ impl<Trans: Transport + Clone> User<Trans> {
         &mut self,
         link_to: &Address,
         psk_ids: &PskIds,
-        ke_pks: &Vec<&Identifier>,
+        ke_pks: &[&Identifier],
     ) -> Result<(Address, Option<Address>)> {
         let msg = self.user.share_keyload(link_to, psk_ids, ke_pks)?;
         self.send_message_sequenced(msg, link_to.rel(), MsgInfo::Keyload).await

--- a/iota-streams-app-channels/src/api/user.rs
+++ b/iota-streams-app-channels/src/api/user.rs
@@ -745,7 +745,7 @@ where
         preparsed: PreparsedMessage<'_, F, Link>,
     ) -> Result<UnwrappedMessage<F, Link, tagged_packet::ContentUnwrap<F, Link>>> {
         self.ensure_appinst(&preparsed)?;
-        let content = tagged_packet::ContentUnwrap::new();
+        let content = tagged_packet::ContentUnwrap::default();
         preparsed.unwrap(&*self.link_store.borrow(), content)
     }
 

--- a/iota-streams-app-channels/src/api/user.rs
+++ b/iota-streams-app-channels/src/api/user.rs
@@ -433,7 +433,7 @@ where
         &'a mut self,
         link_to: &'a Link,
         _psk_ids: &psk::PskIds,
-        pks: &'a Vec<&Identifier>,
+        pks: &'a [&Identifier],
     ) -> Result<
         PreparedMessage<'a, F, Link, LS, keyload::ContentWrap<'a, F, Link, vec::IntoIter<(&Identifier, Vec<u8>)>>>,
     > {
@@ -485,7 +485,7 @@ where
         &mut self,
         link_to: &Link,
         psk_ids: &psk::PskIds,
-        ke_pks: &Vec<&Identifier>,
+        ke_pks: &[&Identifier],
     ) -> Result<WrappedMessage<F, Link>> {
         self.prepare_keyload(link_to, psk_ids, ke_pks)?.wrap()
     }

--- a/iota-streams-app-channels/src/lib.rs
+++ b/iota-streams-app-channels/src/lib.rs
@@ -29,3 +29,12 @@ pub mod message;
 
 /// Author and Subscriber API.
 pub mod api;
+
+/// Get a `Value` given a `Key`
+///
+/// This trait can be implemented to any kind of collection to get an item out of it.
+/// It's meant to be versatile, so it can be implemented for T or &T, and both `Key` and
+/// `Value` can be owned or references as well.
+pub trait Lookup<Key, Value> {
+    fn lookup(&self, key: Key) -> Option<Value>;
+}

--- a/iota-streams-app-channels/src/message/keyload.rs
+++ b/iota-streams-app-channels/src/message/keyload.rs
@@ -122,7 +122,6 @@ where
                                 .commit()?
                                 .mask(&self.key),
                             Identifier::EdPubKey(_pk) => ctx.x25519(
-                                // TODO: refactor
                                 &x25519::PublicKey::from(<[u8; 32]>::try_from(store_id.as_ref())?),
                                 &self.key,
                             ),

--- a/iota-streams-app-channels/src/message/keyload.rs
+++ b/iota-streams-app-channels/src/message/keyload.rs
@@ -50,12 +50,15 @@
 //! 2) Keyload is not authenticated (signed). It can later be implicitly authenticated
 //!     via `SignedPacket`.
 
+use crate::Lookup;
+
 use core::convert::TryFrom;
 use iota_streams_app::{
     identifier::Identifier,
     message::{
         self,
-        *,
+        ContentUnwrapNew,
+        HasLink,
     },
 };
 use iota_streams_core::{
@@ -84,21 +87,23 @@ use iota_streams_ddml::{
     types::*,
 };
 
-pub struct ContentWrap<'a, F, Link: HasLink, Keys> {
+pub struct ContentWrap<'a, F, Link>
+where
+    Link: HasLink,
+{
     pub(crate) link: &'a <Link as HasLink>::Rel,
     pub nonce: NBytes<U16>,
     pub key: NBytes<U32>,
-    pub(crate) keys: Keys,
+    pub(crate) keys: Vec<(&'a Identifier, Vec<u8>)>,
     pub(crate) sig_kp: &'a ed25519::Keypair,
     pub(crate) _phantom: core::marker::PhantomData<(F, Link)>,
 }
 
-impl<'a, F, Link, Keys> message::ContentSizeof<F> for ContentWrap<'a, F, Link, Keys>
+impl<'a, F, Link> message::ContentSizeof<F> for ContentWrap<'a, F, Link>
 where
     F: 'a + PRP, // weird 'a constraint, but compiler requires it somehow?!
     Link: HasLink,
     <Link as HasLink>::Rel: 'a + Eq + SkipFallback<F>,
-    Keys: Clone + ExactSizeIterator<Item = (&'a Identifier, Vec<u8>)>,
 {
     fn sizeof<'c>(&self, ctx: &'c mut sizeof::Context<F>) -> Result<&'c mut sizeof::Context<F>> {
         let store = EmptyLinkStore::<F, <Link as HasLink>::Rel, ()>::default();
@@ -107,23 +112,23 @@ where
             .absorb(&self.nonce)?
             .fork(|ctx| {
                 // fork into new context in order to hash Identifiers
-                ctx.absorb(repeated_keys)?
-                    .repeated(self.keys.clone().into_iter(), |ctx, (id, store_id)| {
-                        let ctx = id.sizeof(ctx)?;
-                        ctx.fork(|ctx| {
-                            // fork in order to skip the actual keyload data which may be unavailable to all recipients
-                            match &id {
-                                Identifier::PskId(_pskid) => ctx
-                                    .absorb(External(<&NBytes<psk::PskSize>>::from(<&[u8]>::from(&store_id))))?
-                                    .commit()?
-                                    .mask(&self.key),
-                                Identifier::EdPubKey(_pk) => ctx.x25519(
-                                    &x25519::PublicKey::from(<[u8; 32]>::try_from(store_id.as_ref())?),
-                                    &self.key,
-                                ),
-                            }
-                        })
+                ctx.absorb(repeated_keys)?.repeated(&self.keys, |ctx, (id, store_id)| {
+                    let ctx = id.sizeof(ctx)?;
+                    ctx.fork(|ctx| {
+                        // fork in order to skip the actual keyload data which may be unavailable to all recipients
+                        match id {
+                            Identifier::PskId(_pskid) => ctx
+                                .absorb(External::<&NBytes<psk::PskSize>>::from(store_id.as_slice()))?
+                                .commit()?
+                                .mask(&self.key),
+                            Identifier::EdPubKey(_pk) => ctx.x25519(
+                                // TODO: refactor
+                                &x25519::PublicKey::from(<[u8; 32]>::try_from(store_id.as_ref())?),
+                                &self.key,
+                            ),
+                        }
                     })
+                })
             })?
             .absorb(External(&self.key))?
             .fork(|ctx| ctx.ed25519(self.sig_kp, HashSig))?
@@ -132,13 +137,12 @@ where
     }
 }
 
-impl<'a, F, Link, Store, Keys> message::ContentWrap<F, Store> for ContentWrap<'a, F, Link, Keys>
+impl<'a, F, Link, Store> message::ContentWrap<F, Store> for ContentWrap<'a, F, Link>
 where
     F: 'a + PRP, // weird 'a constraint, but compiler requires it somehow?!
     Link: HasLink,
     <Link as HasLink>::Rel: 'a + Eq + SkipFallback<F>,
     Store: LinkStore<F, <Link as HasLink>::Rel>,
-    Keys: Clone + ExactSizeIterator<Item = (&'a Identifier, Vec<u8>)>,
 {
     fn wrap<'c, OS: io::OStream>(
         &self,
@@ -158,7 +162,7 @@ where
                             // fork in order to skip the actual keyload data which may be unavailable to all recipients
                             match &id {
                                 Identifier::PskId(_pskid) => ctx
-                                    .absorb(External(<&NBytes<psk::PskSize>>::from(<&[u8]>::from(&store_id))))?
+                                    .absorb(External::<&NBytes<psk::PskSize>>::from(store_id.as_slice()))?
                                     .commit()?
                                     .mask(&self.key),
                                 Identifier::EdPubKey(_pk) => ctx.x25519(
@@ -178,45 +182,34 @@ where
     }
 }
 
-// This whole mess with `'a` and `LookupArg: 'a` is needed in order to allow `LookupPsk`
-// and `LookupKeSk` avoid copying and return `&'a Psk` and `&'a ed25519::PublicKey`.
-pub struct ContentUnwrap<'a, F, Link: HasLink, LookupArg: 'a, LookupPsk, LookupKeSk> {
+pub struct ContentUnwrap<'a, F, Link, PskStore, KeSkStore>
+where
+    Link: HasLink,
+{
     pub link: <Link as HasLink>::Rel,
     pub nonce: NBytes<U16>, // TODO: unify with spongos::Spongos::<F>::NONCE_SIZE)
-    pub(crate) lookup_arg: &'a LookupArg,
-    pub(crate) lookup_psk: LookupPsk,
-
-    #[allow(dead_code)]
+    pub(crate) psk_store: PskStore,
+    pub(crate) ke_sk_store: KeSkStore,
     pub(crate) ke_pk: ed25519::PublicKey,
-    pub(crate) lookup_ke_sk: LookupKeSk,
     pub(crate) key_ids: Vec<Identifier>,
     pub key: Option<NBytes<U32>>, // TODO: unify with spongos::Spongos::<F>::KEY_SIZE
     pub(crate) sig_pk: &'a ed25519::PublicKey,
     _phantom: core::marker::PhantomData<(F, Link)>,
 }
 
-impl<'a, F, Link, LookupArg, LookupPsk, LookupKeSk> ContentUnwrap<'a, F, Link, LookupArg, LookupPsk, LookupKeSk>
+impl<'a, F, Link, PskStore, KeSkStore> ContentUnwrap<'a, F, Link, PskStore, KeSkStore>
 where
     F: PRP,
     Link: HasLink,
-    <Link as HasLink>::Rel: Eq + Default + SkipFallback<F>,
-    LookupArg: 'a,
-    LookupPsk: for<'b> Fn(&'b LookupArg, &Identifier) -> Option<psk::Psk>,
-    LookupKeSk: for<'b> Fn(&'b LookupArg, &Identifier) -> Option<&'b x25519::StaticSecret>,
+    Link::Rel: Eq + Default + SkipFallback<F>,
 {
-    pub fn new(
-        lookup_arg: &'a LookupArg,
-        lookup_psk: LookupPsk,
-        lookup_ke_sk: LookupKeSk,
-        sig_pk: &'a ed25519::PublicKey,
-    ) -> Self {
+    pub fn new(psk_store: PskStore, ke_sk_store: KeSkStore, sig_pk: &'a ed25519::PublicKey) -> Self {
         Self {
             link: <<Link as HasLink>::Rel as Default>::default(),
             nonce: NBytes::default(),
-            lookup_arg,
-            lookup_psk,
+            psk_store,
+            ke_sk_store,
             ke_pk: ed25519::PublicKey::default(),
-            lookup_ke_sk,
             key_ids: Vec::new(),
             key: None,
             sig_pk,
@@ -225,22 +218,24 @@ where
     }
 }
 
-impl<'a, F, Link, Store, LookupArg, LookupPsk, LookupKeSk> message::ContentUnwrap<F, Store>
-    for ContentUnwrap<'a, F, Link, LookupArg, LookupPsk, LookupKeSk>
+impl<'a, 'b, F, Link, LStore, PskStore, KeSkStore> message::ContentUnwrap<F, LStore>
+    for ContentUnwrap<'a, F, Link, PskStore, KeSkStore>
 where
     F: PRP + Clone,
     Link: HasLink,
-    <Link as HasLink>::Rel: Eq + Default + SkipFallback<F>,
-    Store: LinkStore<F, <Link as HasLink>::Rel>,
-    LookupArg: 'a,
-    LookupPsk: for<'b> Fn(&'b LookupArg, &Identifier) -> Option<psk::Psk>,
-    LookupKeSk: for<'b> Fn(&'b LookupArg, &Identifier) -> Option<&'b x25519::StaticSecret>,
+    Link::Rel: Eq + Default + SkipFallback<F>,
+    LStore: LinkStore<F, Link::Rel>,
+    PskStore: for<'c> Lookup<&'c Identifier, psk::Psk>,
+    KeSkStore: for<'c> Lookup<&'c Identifier, &'b x25519::StaticSecret> + 'b,
 {
-    fn unwrap<'c, IS: io::IStream>(
+    fn unwrap<'c, IS>(
         &mut self,
-        store: &Store,
+        store: &LStore,
         ctx: &'c mut unwrap::Context<F, IS>,
-    ) -> Result<&'c mut unwrap::Context<F, IS>> {
+    ) -> Result<&'c mut unwrap::Context<F, IS>>
+    where
+        IS: io::IStream,
+    {
         let mut id_hash = External(NBytes::<U64>::default());
         let mut repeated_keys = Size(0);
         ctx.join(store, &mut self.link)?.absorb(&mut self.nonce)?.fork(|ctx| {
@@ -250,7 +245,7 @@ where
                     ctx.fork(|ctx| {
                         match &id {
                             Identifier::PskId(_id) => {
-                                if let Some(psk) = (self.lookup_psk)(self.lookup_arg, &id) {
+                                if let Some(psk) = self.psk_store.lookup(&id) {
                                     let mut key = NBytes::<U32>::default();
                                     ctx.absorb(External(<&NBytes<psk::PskSize>>::from(&psk)))?
                                         .commit()?
@@ -266,7 +261,7 @@ where
                                 }
                             }
                             Identifier::EdPubKey(ke_pk) => {
-                                if let Some(ke_sk) = (self.lookup_ke_sk)(self.lookup_arg, &id) {
+                                if let Some(ke_sk) = self.ke_sk_store.lookup(&id) {
                                     let mut key = NBytes::<U32>::default();
                                     ctx.x25519(ke_sk, &mut key)?;
                                     self.key = Some(key);

--- a/iota-streams-app-channels/src/message/tagged_packet.rs
+++ b/iota-streams-app-channels/src/message/tagged_packet.rs
@@ -106,15 +106,13 @@ pub struct ContentUnwrap<F, Link: HasLink> {
     pub(crate) _phantom: core::marker::PhantomData<(F, Link)>,
 }
 
-impl<F, Link> ContentUnwrap<F, Link>
+impl<F, Link> Default for ContentUnwrap<F, Link>
 where
     Link: HasLink,
-    <Link as HasLink>::Rel: Eq + Default + SkipFallback<F>,
 {
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
+    fn default() -> Self {
         Self {
-            link: <<Link as HasLink>::Rel as Default>::default(),
+            link: Link::Rel::default(),
             public_payload: Bytes::default(),
             masked_payload: Bytes::default(),
             _phantom: core::marker::PhantomData,

--- a/iota-streams-app/Cargo.toml
+++ b/iota-streams-app/Cargo.toml
@@ -41,7 +41,7 @@ async-trait = { version = "0.1", optional = true }
 atomic_refcell = { version = "0.1.6", optional = true }
 
 # Dependencies for "client" feature
-iota-client = { git = "https://github.com/iotaledger/iota.rs", branch = "dev", default-features = false, optional = true }
+iota-client = { git = "https://github.com/iotaledger/iota.rs", rev  = "283af58b6f9a20b3698e5128e3e651b2a4dce861", default-features = false, optional = true }
 
 num_cpus = { version = "1.10", optional = true }
 

--- a/iota-streams-app/Cargo.toml
+++ b/iota-streams-app/Cargo.toml
@@ -41,7 +41,7 @@ async-trait = { version = "0.1", optional = true }
 atomic_refcell = { version = "0.1.6", optional = true }
 
 # Dependencies for "client" feature
-iota-client = { git = "https://github.com/iotaledger/iota.rs", rev  = "283af58b6f9a20b3698e5128e3e651b2a4dce861", default-features = false, optional = true }
+iota-client = { git = "https://github.com/iotaledger/iota.rs", branch  = "wasm", default-features = false, optional = true }
 
 num_cpus = { version = "1.10", optional = true }
 

--- a/iota-streams-app/src/identifier.rs
+++ b/iota-streams-app/src/identifier.rs
@@ -64,9 +64,9 @@ impl From<ed25519::PublicKey> for Identifier {
     }
 }
 
-impl From<&PskId> for Identifier {
-    fn from(pskid: &PskId) -> Self {
-        Identifier::PskId(*pskid)
+impl From<PskId> for Identifier {
+    fn from(pskid: PskId) -> Self {
+        Identifier::PskId(pskid)
     }
 }
 

--- a/iota-streams-app/src/message/wrapped.rs
+++ b/iota-streams-app/src/message/wrapped.rs
@@ -18,7 +18,7 @@ pub struct WrapState<F, Link> {
 }
 
 impl<F: PRP, Link: HasLink> WrapState<F, Link> {
-    /// Save link for the current wrapped message and accociated info into the store.
+    /// Save link for the current wrapped message and associated info into the store.
     pub fn commit<Store>(
         mut self,
         mut store: RefMut<Store>,

--- a/iota-streams-app/src/transport/tangle/mod.rs
+++ b/iota-streams-app/src/transport/tangle/mod.rs
@@ -24,6 +24,7 @@ use iota_streams_core::{
             U40,
         },
         Box,
+        String,
         ToString,
         Vec,
     },
@@ -414,6 +415,13 @@ impl AppInst {
     }
 }
 
+impl AppInst {
+    /// Get the hexadecimal representation of the AppInst
+    pub fn to_hex_string(&self) -> String {
+        format!("{:x}", self.id)
+    }
+}
+
 impl<'a> From<&'a [u8]> for AppInst {
     fn from(v: &[u8]) -> AppInst {
         AppInst {
@@ -509,6 +517,13 @@ pub const MSGID_SIZE: usize = 12;
 #[derive(Clone, Default, Debug, PartialEq, Eq, Hash)]
 pub struct MsgId {
     pub(crate) id: NBytes<MsgIdSize>,
+}
+
+impl MsgId {
+    /// Get the hexadecimal representation of the MsgId
+    pub fn to_hex_string(&self) -> String {
+        format!("{:x}", self.id)
+    }
 }
 
 impl<'a> From<&'a [u8]> for MsgId {

--- a/iota-streams-app/src/transport/tangle/mod.rs
+++ b/iota-streams-app/src/transport/tangle/mod.rs
@@ -220,7 +220,7 @@ impl TangleAddress {
     }
 
     /// Hash the content of the TangleAddress using `Blake2b256`
-    pub fn to_blake2b(&self) -> NBytes<U32> {
+    fn to_blake2b(&self) -> NBytes<U32> {
         let hasher = blake2b::Blake2b256::new();
         let hash = hasher.chain(&self.appinst).chain(&self.msgid).finalize();
         hash.into()
@@ -228,7 +228,9 @@ impl TangleAddress {
 
     /// Generate the hash used to index the [`TangleMessage`] published in this address
     ///
-    /// Currently this hash is computed with [`to_blake2b`].
+    /// Currently this hash is computed with [Blake2b256].
+    ///
+    /// [Blake2b256]: https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE2|Blake2b256
     pub fn to_msg_index(&self) -> NBytes<U32> {
         self.to_blake2b()
     }

--- a/iota-streams-app/src/transport/tangle/mod.rs
+++ b/iota-streams-app/src/transport/tangle/mod.rs
@@ -6,7 +6,6 @@ use core::{
         AsRef,
     },
     fmt,
-    hash,
     ptr::null,
     str::FromStr,
 };
@@ -21,10 +20,10 @@ use iota_streams_core::{
     prelude::{
         typenum::{
             U12,
+            U32,
             U40,
         },
         Box,
-        String,
         ToString,
         Vec,
     },
@@ -33,7 +32,11 @@ use iota_streams_core::{
         spongos::Spongos,
     },
     wrapped_err,
-    Errors::BadHexFormat,
+    Error,
+    Errors::{
+        BadHexFormat,
+        MalformedAddressString,
+    },
     WrappedError,
 };
 use iota_streams_core_edsig::signature::ed25519;
@@ -138,30 +141,95 @@ impl<F> TangleMessage<F> {
 }
 
 /// Tangle representation of a Message Link
-#[derive(Clone)]
+///
+/// A `TangleAddress` is comprised of 2 distinct parts: the channel identifier
+/// ([`TangleAddress::appinst`]) and the message identifier
+/// ([`TangleAddress::msgid`]). The channel identifier, also refered to as
+/// the channel address, is unique per channel and is common in the
+/// `TangleAddress` of all messages published in it. The message identifier is
+/// produced pseudo-randomly out of the the message's sequence number, the
+/// previous message identifier, and other internal properties.
+///
+/// ## Renderings
+/// ### Blake2b hash
+/// A `TangleAddress` is used as index of the message over the Tangle. For that,
+/// its content is hashed using [`TangleAddress::to_msg_index()`]. If the binary
+/// digest of the hash needs to be encoded in hexadecimal, you can use
+/// [`core::fmt::LowerHex`] or [`core::fmt::UpperHex`]:
+///
+/// ```
+/// # use iota_streams_app::transport::tangle::TangleAddress;
+/// # use iota_streams_ddml::types::NBytes;
+/// #
+/// # fn main() -> anyhow::Result<()> {
+/// let address = TangleAddress::new([172_u8; 40][..].into(), [171_u8; 12][..].into());
+/// assert_eq!(
+///     address.to_msg_index().as_ref(),
+///     &[
+///         44, 181, 155, 1, 109, 141, 169, 177, 209, 70, 226, 18, 190, 121, 40, 44, 90, 108, 159, 109, 241, 37, 30, 0,
+///         185, 80, 245, 59, 235, 75, 128, 97
+///     ],
+/// );
+/// assert_eq!(
+///     format!("{:x}", address.to_msg_index()),
+///     "2cb59b016d8da9b1d146e212be79282c5a6c9f6df1251e00b950f53beb4b8061".to_string()
+/// );
+/// #   Ok(())
+/// # }
+/// ```
+///
+/// ### exchangeable encoding
+/// In order to exchange a `TangleAddress` between channel participants, it can be encoded and decoded
+/// using [`TangleAddress::to_string()`][Display] (or [`format!()`]) and [`TangleAddress::from_str`] (or
+/// [`str::parse()`]). This method encodes the `TangleAddress` as a colon-separated string containing the `appinst` and
+/// `msgid` in hexadecimal:
+/// ```
+/// # use iota_streams_app::transport::tangle::TangleAddress;
+/// # use iota_streams_ddml::types::NBytes;
+/// #
+/// # fn main() -> anyhow::Result<()> {
+/// let address = TangleAddress::new([170_u8; 40][..].into(), [255_u8; 12][..].into());
+/// let address_str = address.to_string();
+/// assert_eq!(
+///     address_str,
+///     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:ffffffffffffffffffffffff"
+///         .to_string(),
+/// );
+/// assert_eq!(address_str.parse::<TangleAddress>()?, address);
+/// #   Ok(())
+/// # }
+/// ```
+///
+/// ## Debugging
+///
+/// For debugging purposes, `TangleAddress` implements `Debug`, which can be triggered with the formatting `{:?}`
+/// or the pretty-printed `{:#?}`. These will output `appinst` and `msgid` as decimal arrays; you can also use
+/// `{:x?}` or `{:#x?}` to render them as hexadecimal arrays.
+///
+/// [Display]: #impl-Display
+#[derive(Debug, Clone, PartialEq, Eq, Default, Hash)]
 pub struct TangleAddress {
     pub appinst: AppInst,
     pub msgid: MsgId,
 }
 
 impl TangleAddress {
-    pub fn from_str(appinst_str: &str, msgid_str: &str) -> Result<Self> {
-        let appinst = AppInst::from_str(appinst_str)
-            .map_err(|e| wrapped_err!(BadHexFormat(appinst_str.into()), WrappedError(e)))?;
-
-        let msgid =
-            MsgId::from_str(msgid_str).map_err(|e| wrapped_err!(BadHexFormat(appinst_str.into()), WrappedError(e)))?;
-
-        Ok(TangleAddress { appinst, msgid })
+    pub fn new(appinst: AppInst, msgid: MsgId) -> Self {
+        Self { appinst, msgid }
     }
 
-    #[allow(clippy::inherent_to_string_shadow_display)]
-    pub fn to_string(&self) -> String {
-        let mut address = String::new();
-        address.push_str(&self.appinst.to_string());
-        address.push(':');
-        address.push_str(&self.msgid.to_string());
-        address
+    /// Hash the content of the TangleAddress using `Blake2b256`
+    pub fn to_blake2b(&self) -> NBytes<U32> {
+        let hasher = blake2b::Blake2b256::new();
+        let hash = hasher.chain(&self.appinst).chain(&self.msgid).finalize();
+        hash.into()
+    }
+
+    /// Generate the hash used to index the [`TangleMessage`] published in this address
+    ///
+    /// Currently this hash is computed with [`to_blake2b`].
+    pub fn to_msg_index(&self) -> NBytes<U32> {
+        self.to_blake2b()
     }
 
     /// # Safety
@@ -170,68 +238,54 @@ impl TangleAddress {
     pub unsafe fn from_c_str(c_addr: *const c_char) -> *const Self {
         c_addr.as_ref().map_or(null(), |c_addr| {
             CStr::from_ptr(c_addr).to_str().map_or(null(), |addr_str| {
-                let addr_vec: Vec<&str> = addr_str.split(':').collect();
-                Self::from_str(addr_vec[0], addr_vec[1]).map_or(null(), |addr| Box::into_raw(Box::new(addr)))
+                Self::from_str(addr_str).map_or(null(), |addr| Box::into_raw(Box::new(addr)))
             })
         })
     }
 }
 
-impl fmt::Debug for TangleAddress {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "<{:?}:{:?}>", self.appinst, self.msgid)
-    }
-}
-
-pub fn get_hash(tx_address: &[u8], tx_tag: &[u8]) -> Result<String> {
-    let total = [tx_address, tx_tag].concat();
-    let hash = blake2b::Blake2b256::digest(&total);
-    Ok(hex::encode(&hash))
-}
-
+/// String representation of a Tangle Link
+///
+/// The current string representation of a Tangle Link is the
+/// colon-separated conjunction of the hex-encoded `appinst` and `msgid`:
+/// `"<appinst>:<msgid>"`.
 impl fmt::Display for TangleAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let hash = get_hash(self.appinst.as_ref(), self.msgid.as_ref()).unwrap_or_default();
-        write!(f, "<{}>", hash)
+        write!(f, "{:x}:{:x}", self.appinst, self.msgid)
     }
 }
 
-impl Default for TangleAddress {
-    fn default() -> Self {
-        Self {
-            appinst: AppInst::default(),
-            msgid: MsgId::default(),
-        }
-    }
-}
+/// Create a TangleAddress out of it's string representation
+///
+/// This method is the opposite of [`TangleAddress::to_string()`][`Display`]
+/// (see [`Display`]): it expects a colon-separated string containing the
+/// hex-encoded `appinst` and `msgid`.
+///
+/// [`Display`]: #impl-Display
+impl FromStr for TangleAddress {
+    type Err = Error;
+    fn from_str(string: &str) -> Result<Self, Self::Err> {
+        let (appinst_str, msgid_str) = string
+            .split_once(':')
+            .ok_or_else(|| wrapped_err!(MalformedAddressString, WrappedError(string)))?;
+        let appinst = AppInst::from_str(appinst_str)
+            .map_err(|e| wrapped_err!(BadHexFormat(appinst_str.into()), WrappedError(e)))?;
 
-impl PartialEq for TangleAddress {
-    fn eq(&self, other: &Self) -> bool {
-        self.appinst == other.appinst && self.msgid == other.msgid
-    }
-}
-impl Eq for TangleAddress {}
+        let msgid =
+            MsgId::from_str(msgid_str).map_err(|e| wrapped_err!(BadHexFormat(appinst_str.into()), WrappedError(e)))?;
 
-impl TangleAddress {
-    pub fn new(appinst: AppInst, msgid: MsgId) -> Self {
-        Self { appinst, msgid }
-    }
-}
-
-impl hash::Hash for TangleAddress {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        self.appinst.hash(state);
-        self.msgid.hash(state);
+        Ok(TangleAddress { appinst, msgid })
     }
 }
 
 impl HasLink for TangleAddress {
     type Base = AppInst;
+    type Rel = MsgId;
+
     fn base(&self) -> &AppInst {
         &self.appinst
     }
 
-    type Rel = MsgId;
     fn rel(&self) -> &MsgId {
         &self.msgid
     }
@@ -340,11 +394,11 @@ impl<F: PRP> LinkGenerator<TangleAddress> for DefaultTangleLinkGenerator<F> {
 }
 
 pub type AppInstSize = U40;
-/// ed25519 public key [32] + 64-bit additional index
+/// ed25519 public key \[32\] + 64-bit additional index
 pub const APPINST_SIZE: usize = 40;
 
 /// 40 byte Application Instance identifier.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug, PartialEq, Eq, Hash)]
 pub struct AppInst {
     pub(crate) id: NBytes<AppInstSize>,
 }
@@ -386,34 +440,28 @@ impl FromStr for AppInst {
     }
 }
 
-impl fmt::Debug for AppInst {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(self.id))
-    }
-}
-
+/// Display AppInst with its hexadecimal representation (lower case)
 impl fmt::Display for AppInst {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(self.id))
+        write!(f, "{:x}", self.id)
     }
 }
 
-impl PartialEq for AppInst {
-    fn eq(&self, other: &Self) -> bool {
-        self.id == other.id
+impl fmt::LowerHex for AppInst {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.id, f)
     }
 }
-impl Eq for AppInst {}
+
+impl fmt::UpperHex for AppInst {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::UpperHex::fmt(&self.id, f)
+    }
+}
 
 impl AsRef<[u8]> for AppInst {
     fn as_ref(&self) -> &[u8] {
         self.id.as_ref()
-    }
-}
-
-impl hash::Hash for AppInst {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        self.id.hash(state);
     }
 }
 
@@ -458,7 +506,7 @@ pub type MsgIdSize = U12;
 pub const MSGID_SIZE: usize = 12;
 
 /// 12 byte Message Identifier unique within application instance.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug, PartialEq, Eq, Hash)]
 pub struct MsgId {
     pub(crate) id: NBytes<MsgIdSize>,
 }
@@ -495,34 +543,28 @@ impl From<NBytes<MsgIdSize>> for MsgId {
     }
 }
 
-impl fmt::Debug for MsgId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(self.id))
-    }
-}
-
+/// Display MsgId with its hexadecimal representation (lower case)
 impl fmt::Display for MsgId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(self.id))
+        write!(f, "{:x}", self.id)
     }
 }
 
-impl PartialEq for MsgId {
-    fn eq(&self, other: &Self) -> bool {
-        self.id == other.id
+impl fmt::LowerHex for MsgId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.id, f)
     }
 }
-impl Eq for MsgId {}
+
+impl fmt::UpperHex for MsgId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::UpperHex::fmt(&self.id, f)
+    }
+}
 
 impl AsRef<[u8]> for MsgId {
     fn as_ref(&self) -> &[u8] {
         self.id.as_ref()
-    }
-}
-
-impl hash::Hash for MsgId {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        self.id.hash(state);
     }
 }
 

--- a/iota-streams-core/src/errors/error_messages.rs
+++ b/iota-streams-core/src/errors/error_messages.rs
@@ -78,6 +78,12 @@ pub enum Errors {
     TransportNotAvailable,
 
     //////////
+    // Iota Transport
+    //////////
+    /// Malformed address string: missing colon (':') separator between appinst and msgid
+    MalformedAddressString,
+
+    //////////
     // Iota Client
     //////////
     /// Iota Message Address failed to generate. // UNUSED

--- a/iota-streams-core/src/lib.rs
+++ b/iota-streams-core/src/lib.rs
@@ -1,6 +1,4 @@
 #![no_std]
-// TODO: Remove this after clippy fixes their false positive bug [https://github.com/rust-lang/rust-clippy/issues/7434]
-#![allow(clippy::nonstandard_macro_braces)]
 //#![feature(generic_associated_types)]
 
 #[cfg(not(feature = "std"))]

--- a/iota-streams-core/src/prelude.rs
+++ b/iota-streams-core/src/prelude.rs
@@ -4,6 +4,7 @@ pub use alloc::{
         self,
         Box,
     },
+    format,
     rc::{
         self,
         Rc,
@@ -29,6 +30,7 @@ pub use std::{
         self,
         Box,
     },
+    format,
     rc::{
         self,
         Rc,

--- a/iota-streams-ddml/src/command/mod.rs
+++ b/iota-streams-ddml/src/command/mod.rs
@@ -90,9 +90,9 @@ pub trait Join<L, S> {
 
 /// Repeated modifier.
 pub trait Repeated<I, F> {
-    /// `values_iter` provides some iterated values or counter.
+    /// `values` provides an iterable over values or counter.
     /// `value_handler` handles one item.
-    fn repeated(&mut self, values_iter: I, value_handle: F) -> Result<&mut Self>;
+    fn repeated(&mut self, values: I, value_handle: F) -> Result<&mut Self>;
 }
 
 /// Condition guard.

--- a/iota-streams-ddml/src/command/sizeof/repeated.rs
+++ b/iota-streams-ddml/src/command/sizeof/repeated.rs
@@ -8,11 +8,11 @@ use crate::command::Repeated;
 /// (absorbed/masked/skipped) explicitly.
 impl<F, I, C> Repeated<I, C> for Context<F>
 where
-    I: iter::Iterator,
-    C: for<'a> FnMut(&'a mut Self, <I as iter::Iterator>::Item) -> Result<&'a mut Self>,
+    I: iter::IntoIterator,
+    C: for<'a> FnMut(&'a mut Self, I::Item) -> Result<&'a mut Self>,
 {
-    fn repeated(&mut self, values_iter: I, mut value_handle: C) -> Result<&mut Self> {
-        values_iter.fold(Ok(self), |rctx, item| -> Result<&mut Self> {
+    fn repeated(&mut self, values: I, mut value_handle: C) -> Result<&mut Self> {
+        values.into_iter().fold(Ok(self), |rctx, item| -> Result<&mut Self> {
             match rctx {
                 Ok(ctx) => value_handle(ctx, item),
                 Err(e) => Err(e),

--- a/iota-streams-ddml/src/command/wrap/repeated.rs
+++ b/iota-streams-ddml/src/command/wrap/repeated.rs
@@ -10,11 +10,11 @@ use iota_streams_core::sponge::prp::PRP;
 
 impl<I, C, F: PRP, OS: io::OStream> Repeated<I, C> for Context<F, OS>
 where
-    I: iter::Iterator,
-    C: for<'a> FnMut(&'a mut Self, <I as iter::Iterator>::Item) -> Result<&'a mut Self>,
+    I: iter::IntoIterator,
+    C: for<'a> FnMut(&'a mut Self, I::Item) -> Result<&'a mut Self>,
 {
-    fn repeated(&mut self, values_iter: I, mut value_handle: C) -> Result<&mut Self> {
-        values_iter.fold(Ok(self), |rctx, item| -> Result<&mut Self> {
+    fn repeated(&mut self, values: I, mut value_handle: C) -> Result<&mut Self> {
+        values.into_iter().fold(Ok(self), |rctx, item| -> Result<&mut Self> {
             match rctx {
                 Ok(ctx) => value_handle(ctx, item),
                 Err(e) => Err(e),

--- a/iota-streams-ddml/src/types/external.rs
+++ b/iota-streams-ddml/src/types/external.rs
@@ -1,4 +1,18 @@
+pub use iota_streams_core::prelude::generic_array::ArrayLength;
+
+use super::NBytes;
+
 /// DDML `external` modifier, it changes behaviour of commands in the following way.
 /// The external field is not encoded in trinary representation and the value is stored in the environment implicitly.
 #[derive(PartialEq, Eq, Copy, Clone, Debug, Default)]
 pub struct External<T>(pub T);
+
+impl<'a, T, N> From<T> for External<&'a NBytes<N>>
+where
+    T: Into<&'a NBytes<N>>,
+    N: ArrayLength<u8>,
+{
+    fn from(origin: T) -> Self {
+        Self(origin.into())
+    }
+}

--- a/iota-streams-ddml/src/types/nbytes.rs
+++ b/iota-streams-ddml/src/types/nbytes.rs
@@ -4,6 +4,7 @@ use core::{
         AsRef,
     },
     fmt,
+    ops::Add,
 };
 
 // Reexport some often used types
@@ -21,7 +22,9 @@ pub use iota_streams_core::prelude::{
     },
 };
 
-/// Fixed-size array of bytes, the size is known at compile time and is not encoded in trinary representation.
+/// Fixed-size array of bytes
+///
+/// The size of the array is known at compile time.
 #[derive(Clone, PartialEq, Eq, Debug, Default, Hash)]
 pub struct NBytes<N: ArrayLength<u8>>(pub GenericArray<u8, N>);
 
@@ -92,5 +95,25 @@ impl<'a, N: ArrayLength<u8>> From<&'a [u8]> for &'a NBytes<N> {
 impl<'a, N: ArrayLength<u8>> From<&'a mut [u8]> for &'a mut NBytes<N> {
     fn from(slice: &mut [u8]) -> &mut NBytes<N> {
         unsafe { &mut *(slice.as_mut_ptr() as *mut NBytes<N>) }
+    }
+}
+
+impl<N> fmt::LowerHex for NBytes<N>
+where
+    N: ArrayLength<u8> + Add,
+    <N as Add>::Output: ArrayLength<u8>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.0, f)
+    }
+}
+
+impl<N> fmt::UpperHex for NBytes<N>
+where
+    N: ArrayLength<u8> + Add,
+    <N as Add>::Output: ArrayLength<u8>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::UpperHex::fmt(&self.0, f)
     }
 }


### PR DESCRIPTION
# Description of change

Some Clippy lints were disabled temporarily to favor speed of delivery of needed features. This PR refactors the several parts of the code to re-enable some of those lints.   

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

Specially relevant breaking changes:
- Messages are now indexed using the binary digest of the `Address` blake2b256 hash. Messages were previously hashed using the hexadecimal encoding of said hash. Warning: old messages will **not** be compatible with this new version.
- `Address` `Display` format now outputs the same as `Address::to_string()`. To get the hash of the address one must use `Address::to_blake2b()` or `Address::to_msg_index()`

## How the change has been tested
Run the following examples:

- streams/examples
- bindings/wasm examples
- bindings/c examples
- iota-streams-app-channels-example

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
