### PR TITLE
Feature: Single Depth Channels

### DIFF
--- a/bindings/c/include/iota_streams/channels.h
+++ b/bindings/c/include/iota_streams/channels.h
@@ -139,6 +139,7 @@ extern err_t auth_receive_sequence(address_t const **seq, author_t *author, addr
 extern err_t auth_gen_next_msg_ids(next_msg_ids_t const **ids, author_t *author);
 // Generic Processing
 extern err_t auth_receive_msg(unwrapped_message_t const **msg, author_t *author, address_t const *address);
+extern err_t auth_receive_msg_by_sequence(unwrapped_message_t const **msg, author_t *author, address_t const *anchor_address, size_t *msg_num);
 // Fetching/Syncing
 extern err_t auth_fetch_next_msgs(unwrapped_messages_t const **umsgs, author_t *author);
 extern err_t auth_fetch_prev_msg(unwrapped_message_t const **umsg, author_t *author, address_t const *address);
@@ -187,6 +188,7 @@ extern err_t sub_receive_sequence(address_t const **address, subscriber_t *subsc
 extern err_t sub_gen_next_msg_ids(next_msg_ids_t const **ids, subscriber_t *subscriber);
 // Generic Message Processing
 extern err_t sub_receive_msg(unwrapped_message_t const *umsg, subscriber_t *subscriber, address_t const *address);
+extern err_t sub_receive_msg_by_sequence(unwrapped_message_t const **msg, subscriber_t *subscriber, address_t const *anchor_address, size_t *msg_num);
 // Fetching/Syncing
 extern err_t sub_fetch_next_msgs(unwrapped_messages_t const **messages, subscriber_t *subscriber);
 extern err_t sub_fetch_prev_msg(unwrapped_message_t const **umsg, subscriber_t *subscriber, address_t const *address);

--- a/bindings/c/include/iota_streams/channels.h
+++ b/bindings/c/include/iota_streams/channels.h
@@ -139,7 +139,7 @@ extern err_t auth_receive_sequence(address_t const **seq, author_t *author, addr
 extern err_t auth_gen_next_msg_ids(next_msg_ids_t const **ids, author_t *author);
 // Generic Processing
 extern err_t auth_receive_msg(unwrapped_message_t const **msg, author_t *author, address_t const *address);
-extern err_t auth_receive_msg_by_sequence(unwrapped_message_t const **msg, author_t *author, address_t const *anchor_address, size_t *msg_num);
+extern err_t auth_receive_msg_by_sequence_number(unwrapped_message_t const **msg, author_t *author, address_t const *anchor_address, size_t *msg_num);
 // Fetching/Syncing
 extern err_t auth_fetch_next_msgs(unwrapped_messages_t const **umsgs, author_t *author);
 extern err_t auth_fetch_prev_msg(unwrapped_message_t const **umsg, author_t *author, address_t const *address);
@@ -188,7 +188,7 @@ extern err_t sub_receive_sequence(address_t const **address, subscriber_t *subsc
 extern err_t sub_gen_next_msg_ids(next_msg_ids_t const **ids, subscriber_t *subscriber);
 // Generic Message Processing
 extern err_t sub_receive_msg(unwrapped_message_t const *umsg, subscriber_t *subscriber, address_t const *address);
-extern err_t sub_receive_msg_by_sequence(unwrapped_message_t const **msg, subscriber_t *subscriber, address_t const *anchor_address, size_t *msg_num);
+extern err_t sub_receive_msg_by_sequence_number(unwrapped_message_t const **msg, subscriber_t *subscriber, address_t const *anchor_address, size_t *msg_num);
 // Fetching/Syncing
 extern err_t sub_fetch_next_msgs(unwrapped_messages_t const **messages, subscriber_t *subscriber);
 extern err_t sub_fetch_prev_msg(unwrapped_message_t const **umsg, subscriber_t *subscriber, address_t const *address);

--- a/bindings/c/src/api/auth.rs
+++ b/bindings/c/src/api/auth.rs
@@ -370,6 +370,25 @@ pub unsafe extern "C" fn auth_receive_msg(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn auth_receive_msg_by_sequence(
+    r: *mut *const UnwrappedMessage,
+    user: *mut Author,
+    anchor_link: *const Address,
+    msg_num: size_t,
+) -> Err {
+    r.as_mut().map_or(Err::NullArgument, |r| {
+        user.as_mut().map_or(Err::NullArgument, |user| {
+            anchor_link.as_ref().map_or(Err::NullArgument, |link| {
+                user.receive_msg_by_sequence(link, msg_num as u32).map_or(Err::OperationFailed, |u| {
+                    *r = safe_into_ptr(u);
+                    Err::Ok
+                })
+            })
+        })
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn auth_fetch_next_msgs(umsgs: *mut *const UnwrappedMessages, user: *mut Author) -> Err {
     user.as_mut().map_or(Err::NullArgument, |user| {
         umsgs.as_mut().map_or(Err::NullArgument, |umsgs| {

--- a/bindings/c/src/api/auth.rs
+++ b/bindings/c/src/api/auth.rs
@@ -370,7 +370,7 @@ pub unsafe extern "C" fn auth_receive_msg(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn auth_receive_msg_by_sequence(
+pub unsafe extern "C" fn auth_receive_msg_by_sequence_number(
     r: *mut *const UnwrappedMessage,
     user: *mut Author,
     anchor_link: *const Address,
@@ -379,7 +379,7 @@ pub unsafe extern "C" fn auth_receive_msg_by_sequence(
     r.as_mut().map_or(Err::NullArgument, |r| {
         user.as_mut().map_or(Err::NullArgument, |user| {
             anchor_link.as_ref().map_or(Err::NullArgument, |link| {
-                user.receive_msg_by_sequence(link, msg_num as u32).map_or(Err::OperationFailed, |u| {
+                user.receive_msg_by_sequence_number(link, msg_num as u32).map_or(Err::OperationFailed, |u| {
                     *r = safe_into_ptr(u);
                     Err::Ok
                 })

--- a/bindings/c/src/api/sub.rs
+++ b/bindings/c/src/api/sub.rs
@@ -391,6 +391,26 @@ pub unsafe extern "C" fn sub_receive_msg(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn sub_receive_msg_by_sequence(
+    r: *mut *const UnwrappedMessage,
+    user: *mut Subscriber,
+    anchor_link: *const Address,
+    msg_num: size_t,
+) -> Err {
+    r.as_mut().map_or(Err::NullArgument, |r| {
+        user.as_mut().map_or(Err::NullArgument, |user| {
+            anchor_link.as_ref().map_or(Err::NullArgument, |link| {
+                user.receive_msg_by_sequence(link, msg_num as u32).map_or(Err::OperationFailed, |u| {
+                    *r = safe_into_ptr(u);
+                    Err::Ok
+                })
+            })
+        })
+    })
+}
+
+
+#[no_mangle]
 pub unsafe extern "C" fn sub_fetch_next_msgs(r: *mut *const UnwrappedMessages, user: *mut Subscriber) -> Err {
     r.as_mut().map_or(Err::NullArgument, |r| {
         user.as_mut().map_or(Err::NullArgument, |user| {

--- a/bindings/c/src/api/sub.rs
+++ b/bindings/c/src/api/sub.rs
@@ -391,7 +391,7 @@ pub unsafe extern "C" fn sub_receive_msg(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn sub_receive_msg_by_sequence(
+pub unsafe extern "C" fn sub_receive_msg_by_sequence_number(
     r: *mut *const UnwrappedMessage,
     user: *mut Subscriber,
     anchor_link: *const Address,
@@ -400,7 +400,7 @@ pub unsafe extern "C" fn sub_receive_msg_by_sequence(
     r.as_mut().map_or(Err::NullArgument, |r| {
         user.as_mut().map_or(Err::NullArgument, |user| {
             anchor_link.as_ref().map_or(Err::NullArgument, |link| {
-                user.receive_msg_by_sequence(link, msg_num as u32).map_or(Err::OperationFailed, |u| {
+                user.receive_msg_by_sequence_number(link, msg_num as u32).map_or(Err::OperationFailed, |u| {
                     *r = safe_into_ptr(u);
                     Err::Ok
                 })

--- a/bindings/wasm/src/author/authorw.rs
+++ b/bindings/wasm/src/author/authorw.rs
@@ -352,8 +352,10 @@ impl Author {
         self.author
             .borrow_mut()
             .receive_msg_by_sequence(
-                &anchor_link.try_into().map_or_else(|_err| ApiAddress::default(), |addr| addr),
-                msg_num
+                &anchor_link
+                    .try_into()
+                    .map_or_else(|_err| ApiAddress::default(), |addr| addr),
+                msg_num,
             )
             .await
             .map_or_else(
@@ -362,7 +364,7 @@ impl Author {
                     let msgs = vec![msg];
                     let response = get_message_contents(msgs);
                     Ok(response[0].copy())
-                }
+                },
             )
     }
 

--- a/bindings/wasm/src/author/authorw.rs
+++ b/bindings/wasm/src/author/authorw.rs
@@ -348,6 +348,25 @@ impl Author {
     }
 
     #[wasm_bindgen(catch)]
+    pub async fn receive_msg_by_sequence(self, anchor_link: Address, msg_num: u32) -> Result<UserResponse> {
+        self.author
+            .borrow_mut()
+            .receive_msg_by_sequence(
+                &anchor_link.try_into().map_or_else(|_err| ApiAddress::default(), |addr| addr),
+                msg_num
+            )
+            .await
+            .map_or_else(
+                |err| Err(JsValue::from_str(&err.to_string())),
+                |msg| {
+                    let msgs = vec![msg];
+                    let response = get_message_contents(msgs);
+                    Ok(response[0].copy())
+                }
+            )
+    }
+
+    #[wasm_bindgen(catch)]
     pub async fn sync_state(self) -> Result<()> {
         loop {
             let msgs = self.author.borrow_mut().fetch_next_msgs().await;

--- a/bindings/wasm/src/author/authorw.rs
+++ b/bindings/wasm/src/author/authorw.rs
@@ -348,10 +348,10 @@ impl Author {
     }
 
     #[wasm_bindgen(catch)]
-    pub async fn receive_msg_by_sequence(self, anchor_link: Address, msg_num: u32) -> Result<UserResponse> {
+    pub async fn receive_msg_by_sequence_number(self, anchor_link: Address, msg_num: u32) -> Result<UserResponse> {
         self.author
             .borrow_mut()
-            .receive_msg_by_sequence(
+            .receive_msg_by_sequence_number(
                 &anchor_link
                     .try_into()
                     .map_or_else(|_err| ApiAddress::default(), |addr| addr),

--- a/bindings/wasm/src/subscriber/subscriberw.rs
+++ b/bindings/wasm/src/subscriber/subscriberw.rs
@@ -233,6 +233,25 @@ impl Subscriber {
     }
 
     #[wasm_bindgen(catch)]
+    pub async fn receive_msg_by_sequence(self, anchor_link: Address, msg_num: u32) -> Result<UserResponse> {
+        self.subscriber
+            .borrow_mut()
+            .receive_msg_by_sequence(
+                &anchor_link.try_into().map_or_else(|_err| ApiAddress::default(), |addr| addr),
+                msg_num
+            )
+            .await
+            .map_or_else(
+                |err| Err(JsValue::from_str(&err.to_string())),
+                |msg| {
+                    let msgs = vec![msg];
+                    let response = get_message_contents(msgs);
+                    Ok(response[0].copy())
+                }
+            )
+    }
+
+    #[wasm_bindgen(catch)]
     pub async fn send_subscribe(self, link: Address) -> Result<UserResponse> {
         self.subscriber
             .borrow_mut()

--- a/bindings/wasm/src/subscriber/subscriberw.rs
+++ b/bindings/wasm/src/subscriber/subscriberw.rs
@@ -237,8 +237,10 @@ impl Subscriber {
         self.subscriber
             .borrow_mut()
             .receive_msg_by_sequence(
-                &anchor_link.try_into().map_or_else(|_err| ApiAddress::default(), |addr| addr),
-                msg_num
+                &anchor_link
+                    .try_into()
+                    .map_or_else(|_err| ApiAddress::default(), |addr| addr),
+                msg_num,
             )
             .await
             .map_or_else(
@@ -247,7 +249,7 @@ impl Subscriber {
                     let msgs = vec![msg];
                     let response = get_message_contents(msgs);
                     Ok(response[0].copy())
-                }
+                },
             )
     }
 

--- a/bindings/wasm/src/subscriber/subscriberw.rs
+++ b/bindings/wasm/src/subscriber/subscriberw.rs
@@ -233,10 +233,10 @@ impl Subscriber {
     }
 
     #[wasm_bindgen(catch)]
-    pub async fn receive_msg_by_sequence(self, anchor_link: Address, msg_num: u32) -> Result<UserResponse> {
+    pub async fn receive_msg_by_sequence_number(self, anchor_link: Address, msg_num: u32) -> Result<UserResponse> {
         self.subscriber
             .borrow_mut()
-            .receive_msg_by_sequence(
+            .receive_msg_by_sequence_number(
                 &anchor_link
                     .try_into()
                     .map_or_else(|_err| ApiAddress::default(), |addr| addr),

--- a/documentation/docs/libraries/c/api_reference.md
+++ b/documentation/docs/libraries/c/api_reference.md
@@ -194,7 +194,7 @@ Receive a message generically without knowing its type.
 | link            | [`address_t const *`](#Address)                  | Address of sequence message         |
 **Returns:** Error code.
 
-#### auth_receive_msg_by_sequence(umsg, author, anchor_link, msg_num): [err_t](#Err)
+#### auth_receive_msg_by_sequence_number(umsg, author, anchor_link, msg_num): [err_t](#Err)
 Receive a message by its msg number in an anchored single depth channel.
 
 | Param           | Type                                             | Description                          |
@@ -487,7 +487,7 @@ Receive a message generically without knowing its type.
 | address         | [`address_t const *`](#Address)                  | Address of the message               |
 **Returns:** Error code.
 
-#### sub_receive_msg_by_sequence(umsg, subscriber, anchor_link, msg_num): [err_t](#Err)
+#### sub_receive_msg_by_sequence_number(umsg, subscriber, anchor_link, msg_num): [err_t](#Err)
 Receive a message by its msg number in an anchored single depth channel.
 
 | Param           | Type                                             | Description                          |

--- a/documentation/docs/libraries/c/api_reference.md
+++ b/documentation/docs/libraries/c/api_reference.md
@@ -194,6 +194,17 @@ Receive a message generically without knowing its type.
 | link            | [`address_t const *`](#Address)                  | Address of sequence message         |
 **Returns:** Error code.
 
+#### auth_receive_msg_by_sequence(umsg, author, anchor_link, msg_num): [err_t](#Err)
+Receive a message by its msg number in an anchored single depth channel.
+
+| Param           | Type                                             | Description                          |
+| --------------- | ------------------------------------------------ | ------------------------------------ |
+| umsg            | [unwrapped_message_t const *](#UnwrappedMessage) | An Unwrapped Message wrapper around the retrieved message. |
+| author          | `author_t *`                                     | Author instance                      |
+| anchor_link     | [`address_t const *`](#Address)                  | Address of anchor message            |
+| msg_num         | `size_t`                                         | Message number                       |
+**Returns:** Error code.
+
 #### auth_sync_state(umsgs, author): [err_t](#Err)
 Synchronise a publishers state prior to sending another message. Retrieves any other messages from the channel 
 to ensure the user state matches all other publishers.
@@ -474,6 +485,17 @@ Receive a message generically without knowing its type.
 | umsg            | [unwrapped_message_t const *](#UnwrappedMessage) | An Unwrapped Message wrapper around the retrieved message. |
 | subscriber      | `subscriber_t *`                                 | Subscriber instance                  |
 | address         | [`address_t const *`](#Address)                  | Address of the message               |
+**Returns:** Error code.
+
+#### sub_receive_msg_by_sequence(umsg, subscriber, anchor_link, msg_num): [err_t](#Err)
+Receive a message by its msg number in an anchored single depth channel.
+
+| Param           | Type                                             | Description                          |
+| --------------- | ------------------------------------------------ | ------------------------------------ |
+| umsg            | [unwrapped_message_t const *](#UnwrappedMessage) | An Unwrapped Message wrapper around the retrieved message. |
+| subscriber      | `subscriber_t *`                                 | Subscriber instance                  |
+| anchor_link     | [`address_t const *`](#Address)                  | Address of anchor message            |
+| msg_num         | `size_t`                                         | Message number                       |
 **Returns:** Error code.
 
 #### sub_sync_state(umsgs, subscriber): [err_t](#Err)

--- a/documentation/docs/libraries/wasm/api_reference.md
+++ b/documentation/docs/libraries/wasm/api_reference.md
@@ -171,7 +171,7 @@ Receive a message generically without knowing its type.
 | link            | [`address`](#Address)         | Address of the message to be fetched |
 **Returns:** A User Response wrapper around the retrieved message.
 
-#### _async -_ receive_msg_by_sequence(anchor_link, msg_num): [UserResponse](#UserResponse)
+#### _async -_ receive_msg_by_sequence_number(anchor_link, msg_num): [UserResponse](#UserResponse)
 Receive a message by its msg number in an anchored single depth channel.
 
 | Param           | Type                          | Description                          |
@@ -399,7 +399,7 @@ Receive a message generically without knowing its type.
 | link            | [`address`](#Address)         | Address of the message to be fetched |
 **Returns:** A User Response wrapper around the retrieved message.
 
-#### _async -_ receive_msg_by_sequence(anchor_link, msg_num): [UserResponse](#UserResponse)
+#### _async -_ receive_msg_by_sequence_number(anchor_link, msg_num): [UserResponse](#UserResponse)
 Receive a message by its msg number in an anchored single depth channel.
 
 | Param           | Type                          | Description                          |

--- a/documentation/docs/libraries/wasm/api_reference.md
+++ b/documentation/docs/libraries/wasm/api_reference.md
@@ -171,6 +171,15 @@ Receive a message generically without knowing its type.
 | link            | [`address`](#Address)         | Address of the message to be fetched |
 **Returns:** A User Response wrapper around the retrieved message.
 
+#### _async -_ receive_msg_by_sequence(anchor_link, msg_num): [UserResponse](#UserResponse)
+Receive a message by its msg number in an anchored single depth channel.
+
+| Param           | Type                          | Description                          |
+| --------------- | ----------------------------- | ------------------------------------ |
+| anchor_link     | [`address`](#Address)         | Anchor message link for the channel  |
+| msg_num         | `number`                     | Number of the message being retrieved|
+**Returns:** A User Response wrapper around the retrieved message.
+
 #### _async -_ sync_state()
 Synchronise a publishers state prior to sending another message. Retrieves any other messages from the channel 
 to ensure the user state matches all other publishers.
@@ -388,6 +397,15 @@ Receive a message generically without knowing its type.
 | Param           | Type                          | Description                          |
 | --------------- | ----------------------------- | ------------------------------------ |
 | link            | [`address`](#Address)         | Address of the message to be fetched |
+**Returns:** A User Response wrapper around the retrieved message.
+
+#### _async -_ receive_msg_by_sequence(anchor_link, msg_num): [UserResponse](#UserResponse)
+Receive a message by its msg number in an anchored single depth channel.
+
+| Param           | Type                          | Description                          |
+| --------------- | ----------------------------- | ------------------------------------ |
+| anchor_link     | [`address`](#Address)         | Anchor message link for the channel  |
+| msg_num         | `number`                     | Number of the message being retrieved|
 **Returns:** A User Response wrapper around the retrieved message.
 
 #### _async -_ sync_state()

--- a/examples/src/branching/mod.rs
+++ b/examples/src/branching/mod.rs
@@ -1,4 +1,5 @@
 pub mod multi_branch;
 pub mod recovery;
 pub mod single_branch;
+pub mod single_depth;
 pub mod utils;

--- a/examples/src/branching/single_depth.rs
+++ b/examples/src/branching/single_depth.rs
@@ -1,0 +1,150 @@
+use iota_streams::{
+    app::message::HasLink,
+    app_channels::api::{
+        psk_from_seed,
+        pskid_from_psk,
+        tangle::{
+            Author,
+            ChannelType,
+            MessageContent,
+            Subscriber,
+            Transport,
+        }
+    },
+    core::{
+        panic_if_not,
+        prelude::Rc,
+        print,
+        println,
+        try_or,
+        Errors::*,
+        Result,
+    },
+    ddml::types::*,
+};
+
+use core::cell::RefCell;
+
+pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_impl: ChannelType, seed: &str) -> Result<()> {
+    let mut author = Author::new(seed, channel_impl, transport.clone());
+    println!("Author single depth?: {}", author.is_single_depth());
+
+    let mut subscriberA = Subscriber::new("SUBSCRIBERA9SEED", transport.clone());
+    let mut subscriberB = Subscriber::new("SUBSCRIBERB9SEED", transport);
+
+    let empty_payload = Bytes(Vec::new());
+
+    println!("\nAnnounce Channel");
+    let announcement_link = {
+        let msg = author.send_announce()?;
+        println!("  msg => <{}> {}", msg.msgid, msg);
+        print!("  Author     : {}", author);
+        msg
+    };
+    println!("Author channel address: {}", author.channel_address().unwrap());
+
+    println!("\nHandle Announce Channel");
+    {
+        subscriberA.receive_announcement(&announcement_link)?;
+        print!("  SubscriberA: {}", subscriberA);
+        try_or!(
+            author.channel_address() == subscriberA.channel_address(),
+            ApplicationInstanceMismatch(String::from("A"))
+        )?;
+        subscriberB.receive_announcement(&announcement_link)?;
+        print!("  SubscriberB: {}", subscriberB);
+        try_or!(
+            author.channel_address() == subscriberB.channel_address(),
+            ApplicationInstanceMismatch(String::from("B"))
+        )?;
+
+        try_or!(
+            subscriberA
+                .channel_address()
+                .map_or(false, |appinst| appinst == announcement_link.base()),
+            ApplicationInstanceMismatch(String::from("A"))
+        )?;
+        try_or!(
+            subscriberA.is_single_depth() == author.is_single_depth(),
+            BranchingFlagMismatch(String::from("A"))
+        )?;
+    }
+
+    // Generate a simple PSK for storage by users
+    let psk = psk_from_seed("A pre shared key".as_bytes());
+    let pskid = pskid_from_psk(&psk);
+    author.store_psk(pskid.clone(), psk.clone())?;
+    subscriberB.store_psk(pskid, psk)?;
+
+    println!("\nSubscribe A");
+    let subscribeA_link = {
+        let msg = subscriberA.send_subscribe(&announcement_link)?;
+        println!("  msg => <{}> {}", msg.msgid, msg);
+        print!("  SubscriberA: {}", subscriberA);
+        msg
+    };
+
+    println!("\nHandle Subscribe A");
+    {
+        author.receive_subscribe(&subscribeA_link)?;
+        print!("  Author     : {}", author);
+    }
+
+    println!("\nShare keyload for everyone [SubscriberA, PSK]");
+    let anchor_msg_link = {
+        let (msg, seq) = author.send_keyload_for_everyone(&announcement_link)?;
+        println!("  msg => <{}> {}", msg.msgid, msg);
+        panic_if_not(seq.is_none());
+        print!("  Author     : {}", author);
+        msg
+    };
+
+    println!("\nHandle Keyload");
+    {
+        subscriberA.receive_keyload(&anchor_msg_link)?;
+        print!("  SubscriberA: {}", subscriberA);
+        subscriberB.receive_keyload(&anchor_msg_link)?;
+        print!("  SubscriberB: {}", subscriberB);
+    }
+
+    println!("\n Sending messages for subscribers");
+    for i in 1..11 {
+        let mut message = String::from("Message ");
+        message.push_str(&i.to_string());
+        let masked_payload = Bytes(message.as_bytes().to_vec());
+        let (msg, seq) = author.send_signed_packet(&anchor_msg_link, &empty_payload, &masked_payload)?;
+        println!("  msg => <{}> {}", msg.msgid, msg);
+        panic_if_not(seq.is_none());
+    }
+    print!("  Author     : {}", author);
+
+    println!("\nSubscriber A fetching all messages");
+    let mut unwrapped = Vec::new();
+    loop {
+        let msgs = subscriberA.fetch_next_msgs();
+        if msgs.is_empty() { break }
+        unwrapped.extend(msgs);
+    }
+
+    assert_eq!(unwrapped.len(), 10);
+    for msg in unwrapped {
+        if let MessageContent::SignedPacket {pk: _, public_payload: _, masked_payload } = &msg.body {
+            println!("  Msg => <{}>: {}", msg.link, String::from_utf8(masked_payload.0.to_vec())?);
+        } else {
+            panic!("Packet found was not a signed packet from author")
+        }
+
+    }
+    print!(" SubscriberA     : {}", subscriberA);
+
+
+    println!("\nSubscriber B fetching message 5");
+    let msg = subscriberB.receive_msg_by_sequence(&anchor_msg_link, 5)?;
+    if let MessageContent::SignedPacket {pk: _, public_payload: _, masked_payload } = &msg.body {
+        println!("  Msg => <{}>: {}", msg.link, String::from_utf8(masked_payload.0.to_vec())?);
+    } else {
+        panic!("Packet found was not a signed packet from author")
+    }
+
+    Ok(())
+}

--- a/examples/src/branching/single_depth.rs
+++ b/examples/src/branching/single_depth.rs
@@ -74,7 +74,7 @@ pub fn example<T: Transport>(transport: Rc<RefCell<T>>, channel_impl: ChannelTyp
     // Generate a simple PSK for storage by users
     let psk = psk_from_seed("A pre shared key".as_bytes());
     let pskid = pskid_from_psk(&psk);
-    author.store_psk(pskid.clone(), psk.clone())?;
+    author.store_psk(pskid, psk)?;
     subscriberB.store_psk(pskid, psk)?;
 
     println!("\nSubscribe A");

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -43,6 +43,15 @@ fn run_single_branch_test<T: Transport>(transport: Rc<RefCell<T>>, seed: &str) {
     println!("#######################################");
 }
 
+fn run_single_depth_test<T: Transport>(transport: Rc<RefCell<T>>, seed: &str) {
+    println!("\tRunning Single Branch Test, seed: {}", seed);
+    match branching::single_depth::example(transport, ChannelType::SingleDepth, seed) {
+        Err(err) => println!("Error in Single Depth test: {:?}", err),
+        Ok(_) => println!("\tSingle Depth Test completed!!"),
+    }
+    println!("#######################################");
+}
+
 fn run_multi_branch_test<T: Transport>(transport: Rc<RefCell<T>>, seed: &str) {
     println!("\tRunning Multi Branch Test, seed: {}", seed);
     match branching::multi_branch::example(transport, ChannelType::MultiBranch, seed) {
@@ -76,8 +85,9 @@ fn main_pure() {
 
     let transport = Rc::new(RefCell::new(transport));
     run_single_branch_test(transport.clone(), "PURESEEDA");
-    run_multi_branch_test(transport.clone(), "PURESEEDB");
-    run_recovery_test(transport, "PURESEEDC");
+    run_single_depth_test(transport.clone(), "PURESEEDB");
+    run_multi_branch_test(transport.clone(), "PURESEEDC");
+    run_recovery_test(transport, "PURESEEDD");
     println!("Done running pure tests without accessing Tangle");
     println!("#######################################");
 }
@@ -96,27 +106,23 @@ fn main_client() {
 
     let transport = Rc::new(RefCell::new(client));
 
-    let alph9 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ9";
-    let seed1: &str = &(0..10)
-        .map(|_| alph9.chars().nth(rand::thread_rng().gen_range(0, 27)).unwrap())
-        .collect::<String>();
-    let seed2: &str = &(0..10)
-        .map(|_| alph9.chars().nth(rand::thread_rng().gen_range(0, 27)).unwrap())
-        .collect::<String>();
-    let seed3: &str = &(0..10)
-        .map(|_| alph9.chars().nth(rand::thread_rng().gen_range(0, 27)).unwrap())
-        .collect::<String>();
-
     println!("#######################################");
     println!("Running tests accessing Tangle via node {}", &node_url);
     println!("#######################################");
     println!("\n");
 
-    run_single_branch_test(transport.clone(), seed1);
-    run_multi_branch_test(transport.clone(), seed2);
-    run_recovery_test(transport, seed3);
+    run_single_branch_test(transport.clone(), &new_seed());
+    run_single_depth_test(transport.clone(), &new_seed());
+    run_multi_branch_test(transport.clone(), &new_seed());
+    run_recovery_test(transport, &new_seed());
     println!("Done running tests accessing Tangle via node {}", &node_url);
     println!("#######################################");
+}
+
+fn new_seed() -> String {
+    let alph9 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ9";
+    (0..10).map(|_| alph9.chars().nth(rand::thread_rng().gen_range(0, 27)).unwrap())
+        .collect::<String>()
 }
 
 #[tokio::main]

--- a/iota-streams-app-channels/src/api/tangle/author.rs
+++ b/iota-streams-app-channels/src/api/tangle/author.rs
@@ -493,7 +493,11 @@ impl<Trans: Transport + Clone> Author<Trans> {
     ///   # Arguments
     ///   * `anchor_link` - Address of the anchor message for the channel
     ///   * `msg_num` - Sequence of sent message (not counting announce or any keyloads)
-    pub async fn receive_msg_by_sequence_number(&mut self, anchor_link: &Address, msg_num: u32) -> Result<UnwrappedMessage> {
+    pub async fn receive_msg_by_sequence_number(
+        &mut self,
+        anchor_link: &Address,
+        msg_num: u32,
+    ) -> Result<UnwrappedMessage> {
         self.user.receive_msg_by_sequence_number(anchor_link, msg_num).await
     }
 }

--- a/iota-streams-app-channels/src/api/tangle/author.rs
+++ b/iota-streams-app-channels/src/api/tangle/author.rs
@@ -302,6 +302,12 @@ impl<Trans: Transport + Clone> Author<Trans> {
     // self.user.handle_unsubscribe(link, MsgInfo::Unsubscribe)
     // }
 
+    /// Receive and process a message with a known anchor link and message number. This can only
+    /// be used if the channel is a single depth channel.
+    ///
+    ///   # Arguments
+    ///   * `anchor_link` - Address of the anchor message for the channel
+    ///   * `msg_num` - Sequence of sent message (not counting announce or any keyloads)
     pub fn receive_msg_by_sequence(&mut self, anchor_link: &Address, msg_num: u32) -> Result<UnwrappedMessage> {
         self.user.receive_msg_by_sequence(anchor_link, msg_num)
     }
@@ -481,6 +487,12 @@ impl<Trans: Transport + Clone> Author<Trans> {
     // self.user.handle_unsubscribe(link, MsgInfo::Unsubscribe).await
     // }
 
+    /// Receive and process a message with a known anchor link and message number. This can only
+    /// be used if the channel is a single depth channel.
+    ///
+    ///   # Arguments
+    ///   * `anchor_link` - Address of the anchor message for the channel
+    ///   * `msg_num` - Sequence of sent message (not counting announce or any keyloads)
     pub async fn receive_msg_by_sequence(&mut self, anchor_link: &Address, msg_num: u32) -> Result<UnwrappedMessage> {
         self.user.receive_msg_by_sequence(anchor_link, msg_num).await
     }

--- a/iota-streams-app-channels/src/api/tangle/author.rs
+++ b/iota-streams-app-channels/src/api/tangle/author.rs
@@ -301,6 +301,10 @@ impl<Trans: Transport + Clone> Author<Trans> {
     // pub pub fn receive_unsubscribe(&mut self, link: Address) -> Result<()> {
     // self.user.handle_unsubscribe(link, MsgInfo::Unsubscribe)
     // }
+
+    pub fn receive_msg_by_sequence(&mut self, anchor_link: &Address, msg_num: u32) -> Result<UnwrappedMessage> {
+        self.user.receive_msg_by_sequence(anchor_link, msg_num)
+    }
 }
 
 #[cfg(feature = "async")]
@@ -476,6 +480,10 @@ impl<Trans: Transport + Clone> Author<Trans> {
     // pub async fn receive_unsubscribe(&mut self, link: Address) -> Result<()> {
     // self.user.handle_unsubscribe(link, MsgInfo::Unsubscribe).await
     // }
+
+    pub async fn receive_msg_by_sequence(&mut self, anchor_link: &Address, msg_num: u32) -> Result<UnwrappedMessage> {
+        self.user.receive_msg_by_sequence(anchor_link, msg_num).await
+    }
 }
 
 impl<Trans: Clone> fmt::Display for Author<Trans> {

--- a/iota-streams-app-channels/src/api/tangle/author.rs
+++ b/iota-streams-app-channels/src/api/tangle/author.rs
@@ -308,8 +308,8 @@ impl<Trans: Transport + Clone> Author<Trans> {
     ///   # Arguments
     ///   * `anchor_link` - Address of the anchor message for the channel
     ///   * `msg_num` - Sequence of sent message (not counting announce or any keyloads)
-    pub fn receive_msg_by_sequence(&mut self, anchor_link: &Address, msg_num: u32) -> Result<UnwrappedMessage> {
-        self.user.receive_msg_by_sequence(anchor_link, msg_num)
+    pub fn receive_msg_by_sequence_number(&mut self, anchor_link: &Address, msg_num: u32) -> Result<UnwrappedMessage> {
+        self.user.receive_msg_by_sequence_number(anchor_link, msg_num)
     }
 }
 
@@ -493,8 +493,8 @@ impl<Trans: Transport + Clone> Author<Trans> {
     ///   # Arguments
     ///   * `anchor_link` - Address of the anchor message for the channel
     ///   * `msg_num` - Sequence of sent message (not counting announce or any keyloads)
-    pub async fn receive_msg_by_sequence(&mut self, anchor_link: &Address, msg_num: u32) -> Result<UnwrappedMessage> {
-        self.user.receive_msg_by_sequence(anchor_link, msg_num).await
+    pub async fn receive_msg_by_sequence_number(&mut self, anchor_link: &Address, msg_num: u32) -> Result<UnwrappedMessage> {
+        self.user.receive_msg_by_sequence_number(anchor_link, msg_num).await
     }
 }
 

--- a/iota-streams-app-channels/src/api/tangle/subscriber.rs
+++ b/iota-streams-app-channels/src/api/tangle/subscriber.rs
@@ -321,8 +321,8 @@ impl<Trans: Transport + Clone> Subscriber<Trans> {
     ///   # Arguments
     ///   * `anchor_link` - Address of the anchor message for the channel
     ///   * `msg_num` - Sequence of sent message (not counting announce or any keyloads)
-    pub fn receive_msg_by_sequence(&mut self, anchor_link: &Address, msg_num: u32) -> Result<UnwrappedMessage> {
-        self.user.receive_msg_by_sequence(anchor_link, msg_num)
+    pub fn receive_msg_by_sequence_number(&mut self, anchor_link: &Address, msg_num: u32) -> Result<UnwrappedMessage> {
+        self.user.receive_msg_by_sequence_number(anchor_link, msg_num)
     }
 }
 
@@ -492,8 +492,8 @@ impl<Trans: Transport + Clone> Subscriber<Trans> {
     ///   # Arguments
     ///   * `anchor_link` - Address of the anchor message for the channel
     ///   * `msg_num` - Sequence of sent message (not counting announce or any keyloads)
-    pub async fn receive_msg_by_sequence(&mut self, anchor_link: &Address, msg_num: u32) -> Result<UnwrappedMessage> {
-        self.user.receive_msg_by_sequence(anchor_link, msg_num).await
+    pub async fn receive_msg_by_sequence_number(&mut self, anchor_link: &Address, msg_num: u32) -> Result<UnwrappedMessage> {
+        self.user.receive_msg_by_sequence_number(anchor_link, msg_num).await
     }
 }
 

--- a/iota-streams-app-channels/src/api/tangle/subscriber.rs
+++ b/iota-streams-app-channels/src/api/tangle/subscriber.rs
@@ -492,7 +492,11 @@ impl<Trans: Transport + Clone> Subscriber<Trans> {
     ///   # Arguments
     ///   * `anchor_link` - Address of the anchor message for the channel
     ///   * `msg_num` - Sequence of sent message (not counting announce or any keyloads)
-    pub async fn receive_msg_by_sequence_number(&mut self, anchor_link: &Address, msg_num: u32) -> Result<UnwrappedMessage> {
+    pub async fn receive_msg_by_sequence_number(
+        &mut self,
+        anchor_link: &Address,
+        msg_num: u32,
+    ) -> Result<UnwrappedMessage> {
         self.user.receive_msg_by_sequence_number(anchor_link, msg_num).await
     }
 }

--- a/iota-streams-app-channels/src/api/tangle/subscriber.rs
+++ b/iota-streams-app-channels/src/api/tangle/subscriber.rs
@@ -315,6 +315,12 @@ impl<Trans: Transport + Clone> Subscriber<Trans> {
         self.user.receive_message(link)
     }
 
+    /// Receive and process a message with a known anchor link and message number. This can only
+    /// be used if the channel is a single depth channel.
+    ///
+    ///   # Arguments
+    ///   * `anchor_link` - Address of the anchor message for the channel
+    ///   * `msg_num` - Sequence of sent message (not counting announce or any keyloads)
     pub fn receive_msg_by_sequence(&mut self, anchor_link: &Address, msg_num: u32) -> Result<UnwrappedMessage> {
         self.user.receive_msg_by_sequence(anchor_link, msg_num)
     }
@@ -480,6 +486,12 @@ impl<Trans: Transport + Clone> Subscriber<Trans> {
         self.user.receive_message(link).await
     }
 
+    /// Receive and process a message with a known anchor link and message number. This can only
+    /// be used if the channel is a single depth channel.
+    ///
+    ///   # Arguments
+    ///   * `anchor_link` - Address of the anchor message for the channel
+    ///   * `msg_num` - Sequence of sent message (not counting announce or any keyloads)
     pub async fn receive_msg_by_sequence(&mut self, anchor_link: &Address, msg_num: u32) -> Result<UnwrappedMessage> {
         self.user.receive_msg_by_sequence(anchor_link, msg_num).await
     }

--- a/iota-streams-app-channels/src/api/tangle/subscriber.rs
+++ b/iota-streams-app-channels/src/api/tangle/subscriber.rs
@@ -1,7 +1,10 @@
 //! Customize Subscriber with default parameters for use over the Tangle.
 
 use core::fmt;
-use iota_streams_core::Result;
+use iota_streams_core::{
+    err,
+    Result,
+};
 
 use super::*;
 use crate::api::tangle::{
@@ -20,6 +23,7 @@ use iota_streams_core::{
         Psk,
         PskId,
     },
+    Errors::SingleDepthOperationFailure,
 };
 use iota_streams_core_edsig::signature::ed25519;
 
@@ -192,6 +196,9 @@ impl<Trans: Transport + Clone> Subscriber<Trans> {
         public_payload: &Bytes,
         masked_payload: &Bytes,
     ) -> Result<(Address, Option<Address>)> {
+        if self.is_single_depth() {
+            return err(SingleDepthOperationFailure);
+        }
         self.user.send_tagged_packet(link_to, public_payload, masked_payload)
     }
 
@@ -207,6 +214,9 @@ impl<Trans: Transport + Clone> Subscriber<Trans> {
         public_payload: &Bytes,
         masked_payload: &Bytes,
     ) -> Result<(Address, Option<Address>)> {
+        if self.is_single_depth() {
+            return err(SingleDepthOperationFailure);
+        }
         self.user.send_signed_packet(link_to, public_payload, masked_payload)
     }
 
@@ -304,6 +314,10 @@ impl<Trans: Transport + Clone> Subscriber<Trans> {
     pub fn receive_msg(&mut self, link: &Address) -> Result<UnwrappedMessage> {
         self.user.receive_message(link)
     }
+
+    pub fn receive_msg_by_sequence(&mut self, anchor_link: &Address, msg_num: u32) -> Result<UnwrappedMessage> {
+        self.user.receive_msg_by_sequence(anchor_link, msg_num)
+    }
 }
 
 #[cfg(feature = "async")]
@@ -343,6 +357,9 @@ impl<Trans: Transport + Clone> Subscriber<Trans> {
         public_payload: &Bytes,
         masked_payload: &Bytes,
     ) -> Result<(Address, Option<Address>)> {
+        if self.is_single_depth() {
+            return err(SingleDepthOperationFailure);
+        }
         self.user
             .send_tagged_packet(link_to, public_payload, masked_payload)
             .await
@@ -360,6 +377,9 @@ impl<Trans: Transport + Clone> Subscriber<Trans> {
         public_payload: &Bytes,
         masked_payload: &Bytes,
     ) -> Result<(Address, Option<Address>)> {
+        if self.is_single_depth() {
+            return err(SingleDepthOperationFailure);
+        }
         self.user
             .send_signed_packet(link_to, public_payload, masked_payload)
             .await
@@ -458,6 +478,10 @@ impl<Trans: Transport + Clone> Subscriber<Trans> {
     ///   * `pk` - Optional ed25519 Public Key of the sending participant. None if unknown
     pub async fn receive_msg(&mut self, link: &Address) -> Result<UnwrappedMessage> {
         self.user.receive_message(link).await
+    }
+
+    pub async fn receive_msg_by_sequence(&mut self, anchor_link: &Address, msg_num: u32) -> Result<UnwrappedMessage> {
+        self.user.receive_msg_by_sequence(anchor_link, msg_num).await
     }
 }
 

--- a/iota-streams-app-channels/src/api/tangle/user.rs
+++ b/iota-streams-app-channels/src/api/tangle/user.rs
@@ -897,7 +897,11 @@ impl<Trans: Transport + Clone> User<Trans> {
     ///   # Arguments
     ///   * `anchor_link` - Address of the anchor message for the channel
     ///   * `msg_num` - Sequence of sent message (not counting announce or any keyloads)
-    pub async fn receive_msg_by_sequence_number(&mut self, anchor_link: &Address, msg_num: u32) -> Result<UnwrappedMessage> {
+    pub async fn receive_msg_by_sequence_number(
+        &mut self,
+        anchor_link: &Address,
+        msg_num: u32,
+    ) -> Result<UnwrappedMessage> {
         if !self.is_single_depth() {
             return err(ChannelNotSingleDepth);
         }

--- a/iota-streams-app-channels/src/api/tangle/user.rs
+++ b/iota-streams-app-channels/src/api/tangle/user.rs
@@ -177,7 +177,7 @@ impl<Trans> User<Trans> {
     fn process_sequence(&mut self, msg: BinaryMessage, store: bool) -> Result<Address> {
         let unwrapped = self.user.handle_sequence(msg, MsgInfo::Sequence, store)?;
         let msg_link = self.user.link_gen.link_from(
-            &unwrapped.body.id,
+            unwrapped.body.id.to_bytes(),
             Cursor::new_at(&unwrapped.body.ref_link, 0, unwrapped.body.seq_num.0 as u32),
         );
         Ok(msg_link)
@@ -206,7 +206,10 @@ impl<Trans: Transport + Clone> User<Trans> {
                 self.user.commit_sequence_to_all(cursor)?;
                 Ok(None)
             }
-
+            WrappedSequence::SingleDepth(cursor) => {
+                self.user.commit_sequence_to_all(cursor)?;
+                Ok(None)
+            }
             WrappedSequence::None => Ok(None),
         }
     }
@@ -323,7 +326,7 @@ impl<Trans: Transport + Clone> User<Trans> {
         if let Some(_addr) = &self.user.appinst {
             let seq_msg = self.user.handle_sequence(msg.binary, MsgInfo::Sequence, true)?.body;
             let msg_id = self.user.link_gen.link_from(
-                &seq_msg.id,
+                seq_msg.id.to_bytes(),
                 Cursor::new_at(&seq_msg.ref_link, 0, seq_msg.seq_num.0 as u32),
             );
 
@@ -527,16 +530,15 @@ impl<Trans: Transport + Clone> User<Trans> {
     ///   # Arguments
     ///   * `anchor_link` - Address of the anchor message for the channel
     ///   * `msg_num` - Sequence of sent message (not counting announce or any keyloads)
-    pub fn receive_msg_by_sequence(&mut self, anchor_link: &Address, msg_num: u32) -> Result<UnwrappedMessage> {
+    pub fn receive_msg_by_sequence_number(&mut self, anchor_link: &Address, msg_num: u32) -> Result<UnwrappedMessage> {
         if !self.is_single_depth() {
             return err(ChannelNotSingleDepth);
         }
         match self.author_public_key() {
             Some(pk) => {
-                // Subtract 1 from the sequence number so users can start from 1 instead of 0
-                let seq_no = self.user.fetch_anchor()?.seq_no - 1;
+                let seq_no = self.user.fetch_anchor()?.seq_no;
                 let cursor = Cursor::new_at(anchor_link.rel(), 0, msg_num + seq_no);
-                let link = self.user.link_gen.link_from(&(*pk).into(), cursor);
+                let link = self.user.link_gen.link_from(pk.as_ref(), cursor);
                 let msg = self.transport.recv_message(&link)?;
                 self.handle_message(msg, false)
             }
@@ -570,7 +572,10 @@ impl<Trans: Transport + Clone> User<Trans> {
                 self.user.commit_sequence_to_all(cursor)?;
                 Ok(None)
             }
-
+            WrappedSequence::SingleDepth(cursor) => {
+                self.user.commit_sequence_to_all(cursor)?;
+                Ok(None)
+            }
             WrappedSequence::None => Ok(None),
         }
     }
@@ -689,7 +694,7 @@ impl<Trans: Transport + Clone> User<Trans> {
         if let Some(_addr) = &self.user.appinst {
             let seq_msg = self.user.handle_sequence(msg.binary, MsgInfo::Sequence, true)?.body;
             let msg_id = self.user.link_gen.link_from(
-                &seq_msg.id,
+                seq_msg.id.to_bytes(),
                 Cursor::new_at(&seq_msg.ref_link, 0, seq_msg.seq_num.0 as u32),
             );
 
@@ -892,16 +897,15 @@ impl<Trans: Transport + Clone> User<Trans> {
     ///   # Arguments
     ///   * `anchor_link` - Address of the anchor message for the channel
     ///   * `msg_num` - Sequence of sent message (not counting announce or any keyloads)
-    pub async fn receive_msg_by_sequence(&mut self, anchor_link: &Address, msg_num: u32) -> Result<UnwrappedMessage> {
+    pub async fn receive_msg_by_sequence_number(&mut self, anchor_link: &Address, msg_num: u32) -> Result<UnwrappedMessage> {
         if !self.is_single_depth() {
             return err(ChannelNotSingleDepth);
         }
         match self.author_public_key() {
             Some(pk) => {
-                // Subtract 1 from the sequence number so users can start from 1 instead of 0
-                let seq_no = self.user.fetch_anchor()?.seq_no - 1;
+                let seq_no = self.user.fetch_anchor()?.seq_no;
                 let cursor = Cursor::new_at(anchor_link.rel(), 0, msg_num + seq_no);
-                let link = self.user.link_gen.link_from(&(*pk).into(), cursor);
+                let link = self.user.link_gen.link_from(pk.as_ref(), cursor);
                 let msg = self.transport.recv_message(&link).await?;
                 self.handle_message(msg, false).await
             }

--- a/iota-streams-app-channels/src/api/user.rs
+++ b/iota-streams-app-channels/src/api/user.rs
@@ -549,7 +549,6 @@ where
         if !self.is_multi_branching() {
             self.store_state_for_all(msg.link.rel().clone(), seq_no.0 as u32 + 1)?;
             if self.is_single_depth() {
-                println!("Adding seq no {}", seq_no.0);
                 self.anchor = Some(Cursor::new_at(msg.link.clone(), 0, seq_no.0 as u32 + 1));
             }
         }

--- a/iota-streams-app-channels/src/api/user.rs
+++ b/iota-streams-app-channels/src/api/user.rs
@@ -785,16 +785,14 @@ where
                     };
 
                     Ok(WrappedSequence::multi_branch(cursor, wrapped))
+                } else if self.is_single_depth() {
+                    Ok(WrappedSequence::SingleDepth(cursor))
                 } else {
-                    if !self.is_single_depth() {
-                        let msg_link = self
-                            .link_gen
-                            .link_from(self.sig_kp.public, Cursor::new_at(&ref_link.clone(), 0, cursor.seq_no));
-                        cursor.link = msg_link.rel().clone();
-                        Ok(WrappedSequence::single_branch(cursor))
-                    } else {
-                        Ok(WrappedSequence::single_depth(cursor))
-                    }
+                    let msg_link = self
+                        .link_gen
+                        .link_from(self.sig_kp.public, Cursor::new_at(&ref_link.clone(), 0, cursor.seq_no));
+                    cursor.link = msg_link.rel().clone();
+                    Ok(WrappedSequence::single_branch(cursor))
                 }
             }
             None => Ok(WrappedSequence::none()),

--- a/iota-streams-app-channels/src/api/user.rs
+++ b/iota-streams-app-channels/src/api/user.rs
@@ -93,7 +93,9 @@ where
         Self::MultiBranch(cursor, wrapped_message)
     }
 
-    pub fn single_depth(cursor: Cursor<Link::Rel>) -> Self { Self::SingleDepth(cursor) }
+    pub fn single_depth(cursor: Cursor<Link::Rel>) -> Self {
+        Self::SingleDepth(cursor)
+    }
 
     pub fn none() -> Self {
         Self::None
@@ -356,10 +358,9 @@ where
         if let Some(author_sig_pk) = &self.author_sig_pk {
             let identifier = Identifier::EdPubKey(ed25519::PublicKeyWrap(*author_sig_pk));
             if let Some(author_ke_pk) = self.key_store.get_ke_pk(&identifier) {
-                let msg_link = self.link_gen.link_from(
-                    self.sig_kp.public,
-                    Cursor::new_at(link_to.rel(), 0, SUB_MESSAGE_NUM),
-                );
+                let msg_link = self
+                    .link_gen
+                    .link_from(self.sig_kp.public, Cursor::new_at(link_to.rel(), 0, SUB_MESSAGE_NUM));
                 let header = HDF::new(msg_link)
                     .with_previous_msg_link(Bytes(link_to.to_bytes()))
                     .with_content_type(SUBSCRIBE)?
@@ -786,10 +787,9 @@ where
                     Ok(WrappedSequence::multi_branch(cursor, wrapped))
                 } else {
                     if !self.is_single_depth() {
-                        let msg_link = self.link_gen.link_from(
-                            self.sig_kp.public,
-                            Cursor::new_at(&ref_link.clone(), 0, cursor.seq_no),
-                        );
+                        let msg_link = self
+                            .link_gen
+                            .link_from(self.sig_kp.public, Cursor::new_at(&ref_link.clone(), 0, cursor.seq_no));
                         cursor.link = msg_link.rel().clone();
                         Ok(WrappedSequence::single_branch(cursor))
                     } else {

--- a/iota-streams-app-channels/src/api/user.rs
+++ b/iota-streams-app-channels/src/api/user.rs
@@ -977,10 +977,9 @@ where
     pub fn fetch_anchor(&self) -> Result<&Cursor<Link>> {
         match &self.anchor {
             Some(anchor) => Ok(anchor),
-            None => err(UserNotRegistered)
+            None => err(UserNotRegistered),
         }
     }
-
 }
 
 impl<F, Link, LG, LS, Keys> ContentSizeof<F> for User<F, Link, LG, LS, Keys>

--- a/iota-streams-app-channels/src/message/keyload.rs
+++ b/iota-streams-app-channels/src/message/keyload.rs
@@ -189,7 +189,6 @@ where
     pub nonce: NBytes<U16>, // TODO: unify with spongos::Spongos::<F>::NONCE_SIZE)
     pub(crate) psk_store: PskStore,
     pub(crate) ke_sk_store: KeSkStore,
-    pub(crate) ke_pk: ed25519::PublicKey,
     pub(crate) key_ids: Vec<Identifier>,
     pub key: Option<NBytes<U32>>, // TODO: unify with spongos::Spongos::<F>::KEY_SIZE
     pub(crate) sig_pk: &'a ed25519::PublicKey,
@@ -208,7 +207,6 @@ where
             nonce: NBytes::default(),
             psk_store,
             ke_sk_store,
-            ke_pk: ed25519::PublicKey::default(),
             key_ids: Vec::new(),
             key: None,
             sig_pk,
@@ -259,13 +257,12 @@ where
                                     ctx.drop(n)
                                 }
                             }
-                            Identifier::EdPubKey(ke_pk) => {
+                            Identifier::EdPubKey(_ke_pk) => {
                                 if let Some(ke_sk) = self.ke_sk_store.lookup(&id) {
                                     let mut key = NBytes::<U32>::default();
                                     ctx.x25519(ke_sk, &mut key)?;
                                     self.key = Some(key);
                                     // Save the relevant public key
-                                    self.ke_pk = ke_pk.0;
                                     self.key_ids.push(id);
                                     Ok(ctx)
                                 } else {

--- a/iota-streams-app/src/message/link.rs
+++ b/iota-streams-app/src/message/link.rs
@@ -123,7 +123,7 @@ pub trait LinkGenerator<Link: HasLink>: Default {
     fn uniform_link_from(&self, cursor: Cursor<&<Link as HasLink>::Rel>) -> Link;
 
     /// Used by users to pseudo-randomly generate a new message link from a cursor
-    fn link_from(&self, id: &Identifier, cursor: Cursor<&<Link as HasLink>::Rel>) -> Link;
+    fn link_from<T: AsRef<[u8]>>(&self, id: T, cursor: Cursor<&<Link as HasLink>::Rel>) -> Link;
 
     /// Derive a new link and construct a header with given content type.
     fn uniform_header_from(
@@ -156,7 +156,7 @@ pub trait LinkGenerator<Link: HasLink>: Default {
         previous_msg_link: &Link,
     ) -> Result<HDF<Link>> {
         HDF::new_with_fields(
-            self.link_from(id, cursor),
+            self.link_from(id.to_bytes(), cursor),
             Bytes(previous_msg_link.to_bytes()),
             content_type,
             payload_length,

--- a/iota-streams-app/src/transport/tangle/mod.rs
+++ b/iota-streams-app/src/transport/tangle/mod.rs
@@ -388,7 +388,7 @@ impl<F: PRP> LinkGenerator<TangleAddress> for DefaultTangleLinkGenerator<F> {
     fn link_from<T: AsRef<[u8]>>(&self, id: T, cursor: Cursor<&MsgId>) -> TangleAddress {
         TangleAddress {
             appinst: self.addr.appinst.clone(),
-            msgid: self.gen_msgid(&id.as_ref(), cursor),
+            msgid: self.gen_msgid(id.as_ref(), cursor),
         }
     }
 }

--- a/iota-streams-app/src/transport/tangle/mod.rs
+++ b/iota-streams-app/src/transport/tangle/mod.rs
@@ -50,15 +50,12 @@ use iota_streams_ddml::{
 use cstr_core::CStr;
 use cty::c_char;
 
-use crate::{
-    identifier::Identifier,
-    message::{
-        BinaryMessage,
-        Cursor,
-        HasLink,
-        LinkGenerator,
-        LinkedMessage,
-    },
+use crate::message::{
+    BinaryMessage,
+    Cursor,
+    HasLink,
+    LinkGenerator,
+    LinkedMessage,
 };
 
 /// Number of bytes to be placed in each transaction (Maximum HDF Payload Count)
@@ -348,10 +345,10 @@ impl<F: PRP> DefaultTangleLinkGenerator<F> {
         s.squeeze(new.id.as_mut());
         new
     }
-    fn gen_msgid(&self, id: &Identifier, cursor: Cursor<&MsgId>) -> MsgId {
+    fn gen_msgid(&self, id_bytes: &[u8], cursor: Cursor<&MsgId>) -> MsgId {
         let mut s = Spongos::<F>::init();
         s.absorb(self.addr.appinst.id.as_ref());
-        s.absorb(id.to_bytes());
+        s.absorb(id_bytes);
         s.absorb(cursor.link.id.as_ref());
         s.absorb(&cursor.branch_no.to_be_bytes());
         s.absorb(&cursor.seq_no.to_be_bytes());
@@ -366,7 +363,7 @@ impl<F: PRP> LinkGenerator<TangleAddress> for DefaultTangleLinkGenerator<F> {
     /// Used by Author to generate a new application instance: channels address and announcement message identifier
     fn gen(&mut self, pk: &ed25519::PublicKey, channel_idx: u64) {
         self.addr.appinst = AppInst::new(pk, channel_idx);
-        self.addr.msgid = self.gen_msgid(&Identifier::EdPubKey((*pk).into()), Cursor::default().as_ref());
+        self.addr.msgid = self.gen_msgid(pk.as_ref(), Cursor::default().as_ref());
     }
 
     /// Used by Author to get announcement message id, it's just stored internally by link generator
@@ -388,10 +385,10 @@ impl<F: PRP> LinkGenerator<TangleAddress> for DefaultTangleLinkGenerator<F> {
     }
 
     /// Used by users to pseudo-randomly generate a new message link from a cursor
-    fn link_from(&self, id: &Identifier, cursor: Cursor<&MsgId>) -> TangleAddress {
+    fn link_from<T: AsRef<[u8]>>(&self, id: T, cursor: Cursor<&MsgId>) -> TangleAddress {
         TangleAddress {
             appinst: self.addr.appinst.clone(),
-            msgid: self.gen_msgid(id, cursor),
+            msgid: self.gen_msgid(&id.as_ref(), cursor),
         }
     }
 }

--- a/iota-streams-core/src/errors/error_messages.rs
+++ b/iota-streams-core/src/errors/error_messages.rs
@@ -150,6 +150,10 @@ pub enum Errors {
     ChannelDuplication,
     /// Subscriber already has a psk stored, cannot add another
     SinglePskAllowance,
+    /// Subscriber send operations are not allowed in Single Depth mode
+    SingleDepthOperationFailure,
+    /// Operation only available on single depth channels
+    ChannelNotSingleDepth,
 
     //////////
     // User Recovery


### PR DESCRIPTION
# Description of change
Add the third implementation type to Channels. This is the `SingleDepth` implementation. It allows a single publisher (the Author) to send messages that, instead of chaining, surround a single anchor message and can be retrieved by a corresponding sequence number. The retrieval method has been added and can be used like so: 
Rust:
```Rust
let msg = subscriber.receive_msg_by_sequence(anchor_link, msg_num)?;
match msg.body {
    MessageContent::SignedPacket { pk, public_payload, masked_payload } => { ... }, 
    MessageContent::TaggedPacket { public_payload, masked_payload } => { ... }, 
    _ => { Err(...) } // You should only be processing tagged and signed packets
}
```
C:
```C
unwrapped_message_t const *message_return = NULL;
err = auth_receive_msg_by_sequence(&message_return, author, anchor_link, msg_num);
if(e) { 
      printf("Error code: %d\n", e); 
} else { 
    packet_payloads_t response = get_payload(message_return);
    printf("Public: '%s'\n", response.public_payload.ptr);
    printf("Masked: '%s'\n", response.masked_payload.ptr);
}
```

WASM:
```JS
let response = await sub.clone().receive_msg_by_sequence(anchor_link, msg_num);
let msg = response.get_message();
let public_payload = msg.get_public_payload();
let masked_payload = msg.get_masked_payload();
```

## Type of change
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested
A new example has been added to the examples section to demonstrate/test behaviour

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
