### PR TITLE
Support selecting transport in examples with env

### DIFF
--- a/examples/src/branching/multi_branch.rs
+++ b/examples/src/branching/multi_branch.rs
@@ -8,7 +8,7 @@ use iota_streams::{
             ChannelType,
             Subscriber,
             Transport,
-        }
+        },
     },
     core::{
         prelude::HashMap,
@@ -82,7 +82,7 @@ pub async fn example<T: Transport>(transport: T, channel_type: ChannelType, seed
     subscriberC.store_psk(pskid, psk)?;
 
     // Fetch state of subscriber for comparison after reset
-    let sub_a_start_state: HashMap<_,_> = subscriberA.fetch_state()?.into_iter().collect();
+    let sub_a_start_state: HashMap<_, _> = subscriberA.fetch_state()?.into_iter().collect();
 
     println!("\nSubscribe A");
     let subscribeA_link = {
@@ -108,7 +108,10 @@ pub async fn example<T: Transport>(transport: T, channel_type: ChannelType, seed
         (msg, seq)
     };
 
-    println!("\nHandle Share keyload for everyone [SubscriberA, PSK]: {}", &keyload_link);
+    println!(
+        "\nHandle Share keyload for everyone [SubscriberA, PSK]: {}",
+        &keyload_link
+    );
     {
         let msg_tag = subscriberA.receive_sequence(&keyload_seq).await?;
         let resultB = subscriberB.receive_keyload(&msg_tag).await?;
@@ -120,7 +123,6 @@ pub async fn example<T: Transport>(transport: T, channel_type: ChannelType, seed
 
         subscriberC.receive_keyload(&msg_tag).await?;
         print!("  SubscriberC: {}", subscriberC);
-
     }
 
     println!("\nSubscriber A fetching transactions...");
@@ -128,7 +130,9 @@ pub async fn example<T: Transport>(transport: T, channel_type: ChannelType, seed
 
     println!("\nTagged packet 1 - SubscriberA");
     let (tagged_packet_link, tagged_packet_seq) = {
-        let (msg, seq) = subscriberA.send_tagged_packet(&keyload_link, &public_payload, &masked_payload).await?;
+        let (msg, seq) = subscriberA
+            .send_tagged_packet(&keyload_link, &public_payload, &masked_payload)
+            .await?;
         let seq = seq.unwrap();
         println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         println!("  seq => <{}> <{:x}>", seq.msgid, seq.to_msg_index());
@@ -171,7 +175,9 @@ pub async fn example<T: Transport>(transport: T, channel_type: ChannelType, seed
 
     println!("\nSigned packet");
     let (_signed_packet_link, signed_packet_seq) = {
-        let (msg, seq) = author.send_signed_packet(&tagged_packet_link, &public_payload, &masked_payload).await?;
+        let (msg, seq) = author
+            .send_signed_packet(&tagged_packet_link, &public_payload, &masked_payload)
+            .await?;
         let seq = seq.unwrap();
         println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         println!("  seq => <{}> <{:x}>", seq.msgid, seq.to_msg_index());
@@ -236,7 +242,9 @@ pub async fn example<T: Transport>(transport: T, channel_type: ChannelType, seed
 
     println!("\nTagged packet 2 - SubscriberA");
     let (tagged_packet_link, tagged_packet_seq) = {
-        let (msg, seq) = subscriberA.send_tagged_packet(&keyload_link, &public_payload, &masked_payload).await?;
+        let (msg, seq) = subscriberA
+            .send_tagged_packet(&keyload_link, &public_payload, &masked_payload)
+            .await?;
         let seq = seq.unwrap();
         println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         println!("  seq => <{}> <{:x}>", seq.msgid, seq.to_msg_index());
@@ -275,7 +283,9 @@ pub async fn example<T: Transport>(transport: T, channel_type: ChannelType, seed
 
     println!("\nTagged packet 3 - SubscriberB");
     let (tagged_packet_link, tagged_packet_seq) = {
-        let (msg, seq) = subscriberB.send_tagged_packet(&tagged_packet_link, &public_payload, &masked_payload).await?;
+        let (msg, seq) = subscriberB
+            .send_tagged_packet(&tagged_packet_link, &public_payload, &masked_payload)
+            .await?;
         let seq = seq.unwrap();
         println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         println!("  seq => <{}> <{:x}>", seq.msgid, seq.to_msg_index());
@@ -315,7 +325,9 @@ pub async fn example<T: Transport>(transport: T, channel_type: ChannelType, seed
 
     println!("\nTagged packet 4 - SubscriberC");
     let (tagged_packet_link, tagged_packet_seq) = {
-        let (msg, seq) = subscriberC.send_tagged_packet(&tagged_packet_link, &public_payload, &masked_payload).await?;
+        let (msg, seq) = subscriberC
+            .send_tagged_packet(&tagged_packet_link, &public_payload, &masked_payload)
+            .await?;
         let seq = seq.unwrap();
         println!("  msg => <{}> {}", msg.msgid, msg);
         println!("  seq => <{}> {}", seq.msgid, seq);
@@ -348,7 +360,6 @@ pub async fn example<T: Transport>(transport: T, channel_type: ChannelType, seed
             masked_payload == unwrapped_masked,
             MaskedPayloadMismatch(masked_payload.to_string(), unwrapped_masked.to_string())
         )?;
-
     }
 
     println!("\nAuthor fetching transactions...");
@@ -356,7 +367,9 @@ pub async fn example<T: Transport>(transport: T, channel_type: ChannelType, seed
 
     println!("\nSigned packet");
     let (signed_packet_link, signed_packet_seq) = {
-        let (msg, seq) = author.send_signed_packet(&tagged_packet_seq, &public_payload, &masked_payload).await?;
+        let (msg, seq) = author
+            .send_signed_packet(&tagged_packet_seq, &public_payload, &masked_payload)
+            .await?;
         let seq = seq.unwrap();
         println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         println!("  seq => <{}> <{:x}>", seq.msgid, seq.to_msg_index());
@@ -416,7 +429,7 @@ pub async fn example<T: Transport>(transport: T, channel_type: ChannelType, seed
     }
 
     subscriberA.reset_state()?;
-    let new_state: HashMap<_,_>  = subscriberA.fetch_state()?.into_iter().collect();
+    let new_state: HashMap<_, _> = subscriberA.fetch_state()?.into_iter().collect();
 
     println!("\nSubscriber A resetting state");
     let mut matches = false;

--- a/examples/src/branching/multi_branch.rs
+++ b/examples/src/branching/multi_branch.rs
@@ -78,7 +78,7 @@ pub async fn example<T: Transport>(transport: T, channel_type: ChannelType, seed
     // Generate a simple PSK for storage by users
     let psk = psk_from_seed("A pre shared key".as_bytes());
     let pskid = pskid_from_psk(&psk);
-    author.store_psk(pskid.clone(), psk.clone())?;
+    author.store_psk(pskid, psk)?;
     subscriberC.store_psk(pskid, psk)?;
 
     // Fetch state of subscriber for comparison after reset

--- a/examples/src/branching/recovery.rs
+++ b/examples/src/branching/recovery.rs
@@ -60,7 +60,9 @@ pub async fn example<T: Transport>(transport: T, channel_type: ChannelType, seed
     for i in 1..6 {
         println!("Signed packet {} - Author", i);
         previous_msg_link = {
-            let (msg, seq) = author.send_signed_packet(&previous_msg_link, &public_payload, &masked_payload).await?;
+            let (msg, seq) = author
+                .send_signed_packet(&previous_msg_link, &public_payload, &masked_payload)
+                .await?;
             println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
             panic_if_not(seq.is_none());
             msg
@@ -75,7 +77,9 @@ pub async fn example<T: Transport>(transport: T, channel_type: ChannelType, seed
     for i in 6..11 {
         println!("Tagged packet {} - SubscriberA", i);
         previous_msg_link = {
-            let (msg, seq) = subscriberA.send_tagged_packet(&previous_msg_link, &public_payload, &masked_payload).await?;
+            let (msg, seq) = subscriberA
+                .send_tagged_packet(&previous_msg_link, &public_payload, &masked_payload)
+                .await?;
             println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
             panic_if_not(seq.is_none());
             msg
@@ -108,7 +112,9 @@ pub async fn example<T: Transport>(transport: T, channel_type: ChannelType, seed
     }
 
     println!("States match...\nSending next sequenced message...");
-    let (last_msg, _seq) = new_author.send_signed_packet(latest_link, &public_payload, &masked_payload).await?;
+    let (last_msg, _seq) = new_author
+        .send_signed_packet(latest_link, &public_payload, &masked_payload)
+        .await?;
     println!("  msg => <{}> <{:x}>", last_msg.msgid, last_msg.to_msg_index());
 
     // Wait a second for message to propagate

--- a/examples/src/branching/single_branch.rs
+++ b/examples/src/branching/single_branch.rs
@@ -80,7 +80,7 @@ pub async fn example<T: Transport>(transport: T, channel_impl: ChannelType, seed
     // Generate a simple PSK for storage by users
     let psk = psk_from_seed("A pre shared key".as_bytes());
     let pskid = pskid_from_psk(&psk);
-    author.store_psk(pskid.clone(), psk.clone())?;
+    author.store_psk(pskid, psk)?;
     subscriberC.store_psk(pskid, psk)?;
 
     // Fetch state of subscriber for comparison after reset

--- a/examples/src/branching/single_branch.rs
+++ b/examples/src/branching/single_branch.rs
@@ -8,7 +8,7 @@ use iota_streams::{
             ChannelType,
             Subscriber,
             Transport,
-        }
+        },
     },
     core::{
         panic_if_not,
@@ -84,7 +84,7 @@ pub async fn example<T: Transport>(transport: T, channel_impl: ChannelType, seed
     subscriberC.store_psk(pskid, psk)?;
 
     // Fetch state of subscriber for comparison after reset
-    let sub_a_start_state: HashMap<_,_> = subscriberA.fetch_state()?.into_iter().collect();
+    let sub_a_start_state: HashMap<_, _> = subscriberA.fetch_state()?.into_iter().collect();
 
     println!("\nSubscribe A");
     let subscribeA_link = {
@@ -135,7 +135,9 @@ pub async fn example<T: Transport>(transport: T, channel_impl: ChannelType, seed
 
     println!("\nSigned packet");
     let previous_msg_link = {
-        let (msg, seq) = author.send_signed_packet(&previous_msg_link, &public_payload, &masked_payload).await?;
+        let (msg, seq) = author
+            .send_signed_packet(&previous_msg_link, &public_payload, &masked_payload)
+            .await?;
         println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         panic_if_not(seq.is_none());
         print!("  Author     : {}", author);
@@ -144,7 +146,8 @@ pub async fn example<T: Transport>(transport: T, channel_impl: ChannelType, seed
 
     println!("\nHandle Signed packet");
     {
-        let (_signer_pk, unwrapped_public, unwrapped_masked) = subscriberA.receive_signed_packet(&previous_msg_link).await?;
+        let (_signer_pk, unwrapped_public, unwrapped_masked) =
+            subscriberA.receive_signed_packet(&previous_msg_link).await?;
         print!("  SubscriberA: {}", subscriberA);
         try_or!(
             public_payload == unwrapped_public,
@@ -163,7 +166,9 @@ pub async fn example<T: Transport>(transport: T, channel_impl: ChannelType, seed
 
     println!("\nTagged packet 1 - SubscriberA");
     let previous_msg_link = {
-        let (msg, seq) = subscriberA.send_tagged_packet(&previous_msg_link, &public_payload, &masked_payload).await?;
+        let (msg, seq) = subscriberA
+            .send_tagged_packet(&previous_msg_link, &public_payload, &masked_payload)
+            .await?;
         println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         panic_if_not(seq.is_none());
         print!("  SubscriberA: {}", subscriberA);
@@ -183,7 +188,7 @@ pub async fn example<T: Transport>(transport: T, channel_impl: ChannelType, seed
             PublicPayloadMismatch(masked_payload.to_string(), unwrapped_masked.to_string())
         )?;
 
-        let  (unwrapped_public, unwrapped_masked) = subscriberC.receive_tagged_packet(&previous_msg_link).await?;
+        let (unwrapped_public, unwrapped_masked) = subscriberC.receive_tagged_packet(&previous_msg_link).await?;
         print!("  SubscriberC: {}", subscriberC);
         try_or!(
             public_payload == unwrapped_public,
@@ -197,7 +202,9 @@ pub async fn example<T: Transport>(transport: T, channel_impl: ChannelType, seed
 
     println!("\nTagged packet 2 - SubscriberA");
     let previous_msg_link = {
-        let (msg, seq) = subscriberA.send_tagged_packet(&previous_msg_link, &public_payload, &masked_payload).await?;
+        let (msg, seq) = subscriberA
+            .send_tagged_packet(&previous_msg_link, &public_payload, &masked_payload)
+            .await?;
         println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         panic_if_not(seq.is_none());
         print!("  SubscriberA: {}", subscriberA);
@@ -206,7 +213,9 @@ pub async fn example<T: Transport>(transport: T, channel_impl: ChannelType, seed
 
     println!("\nTagged packet 3 - SubscriberA");
     let previous_msg_link = {
-        let (msg, seq) = subscriberA.send_tagged_packet(&previous_msg_link, &public_payload, &masked_payload).await?;
+        let (msg, seq) = subscriberA
+            .send_tagged_packet(&previous_msg_link, &public_payload, &masked_payload)
+            .await?;
         println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         panic_if_not(seq.is_none());
         print!("  SubscriberA: {}", subscriberA);
@@ -220,7 +229,9 @@ pub async fn example<T: Transport>(transport: T, channel_impl: ChannelType, seed
 
     println!("\nTagged packet 4 - SubscriberB");
     let previous_msg_link = {
-        let (msg, seq) = subscriberB.send_tagged_packet(&previous_msg_link, &public_payload, &masked_payload).await?;
+        let (msg, seq) = subscriberB
+            .send_tagged_packet(&previous_msg_link, &public_payload, &masked_payload)
+            .await?;
         println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         panic_if_not(seq.is_none());
         print!("  SubscriberB: {}", subscriberB);
@@ -251,16 +262,16 @@ pub async fn example<T: Transport>(transport: T, channel_impl: ChannelType, seed
             masked_payload == unwrapped_masked,
             PublicPayloadMismatch(masked_payload.to_string(), unwrapped_masked.to_string())
         )?;
-
     }
 
     println!("\nSubscriber fetching transactions...");
     utils::s_fetch_next_messages(&mut subscriberC).await;
 
-
     println!("\nTagged packet 5 - SubscriberC");
     let previous_msg_link = {
-        let (msg, seq) = subscriberC.send_tagged_packet(&previous_msg_link, &public_payload, &masked_payload).await?;
+        let (msg, seq) = subscriberC
+            .send_tagged_packet(&previous_msg_link, &public_payload, &masked_payload)
+            .await?;
         println!("  msg => <{}> {:x}", msg.msgid, msg.to_msg_index());
         panic_if_not(seq.is_none());
         print!("  SubscriberC: {}", subscriberC);
@@ -297,7 +308,9 @@ pub async fn example<T: Transport>(transport: T, channel_impl: ChannelType, seed
 
     println!("\nSigned packet");
     let signed_packet_link = {
-        let (msg, seq) = author.send_signed_packet(&previous_msg_link, &public_payload, &masked_payload).await?;
+        let (msg, seq) = author
+            .send_signed_packet(&previous_msg_link, &public_payload, &masked_payload)
+            .await?;
         println!("  msg => <{}> <{:x}>", msg.msgid, msg.to_msg_index());
         panic_if_not(seq.is_none());
         print!("  Author     : {}", author);
@@ -351,7 +364,7 @@ pub async fn example<T: Transport>(transport: T, channel_impl: ChannelType, seed
     }
 
     subscriberA.reset_state()?;
-    let new_state: HashMap<_,_>  = subscriberA.fetch_state()?.into_iter().collect();
+    let new_state: HashMap<_, _> = subscriberA.fetch_state()?.into_iter().collect();
 
     println!("\nSubscriber A resetting state");
     let mut matches = false;

--- a/examples/src/branching/single_depth.rs
+++ b/examples/src/branching/single_depth.rs
@@ -9,7 +9,7 @@ use iota_streams::{
             MessageContent,
             Subscriber,
             Transport,
-        }
+        },
     },
     core::{
         panic_if_not,
@@ -110,7 +110,9 @@ pub async fn example<T: Transport>(transport: T, channel_impl: ChannelType, seed
         let mut message = String::from("Message ");
         message.push_str(&i.to_string());
         let masked_payload = Bytes(message.as_bytes().to_vec());
-        let (msg, seq) = author.send_signed_packet(&anchor_msg_link, &empty_payload, &masked_payload).await?;
+        let (msg, seq) = author
+            .send_signed_packet(&anchor_msg_link, &empty_payload, &masked_payload)
+            .await?;
         println!("  msg => <{}> {}", msg.msgid, msg.to_msg_index());
         panic_if_not(seq.is_none());
     }
@@ -120,26 +122,44 @@ pub async fn example<T: Transport>(transport: T, channel_impl: ChannelType, seed
     let mut unwrapped = Vec::new();
     loop {
         let msgs = subscriberA.fetch_next_msgs().await;
-        if msgs.is_empty() { break }
+        if msgs.is_empty() {
+            break;
+        }
         unwrapped.extend(msgs);
     }
 
     assert_eq!(unwrapped.len(), 10);
     for msg in unwrapped {
-        if let MessageContent::SignedPacket {pk: _, public_payload: _, masked_payload } = &msg.body {
-            println!("  Msg => <{}>: {}", msg.link.msgid, String::from_utf8(masked_payload.0.to_vec())?);
+        if let MessageContent::SignedPacket {
+            pk: _,
+            public_payload: _,
+            masked_payload,
+        } = &msg.body
+        {
+            println!(
+                "  Msg => <{}>: {}",
+                msg.link.msgid,
+                String::from_utf8(masked_payload.0.to_vec())?
+            );
         } else {
             panic!("Packet found was not a signed packet from author")
         }
-
     }
     print!(" SubscriberA     : {}", subscriberA);
 
-
     println!("\nSubscriber B fetching 4th message");
     let msg = subscriberB.receive_msg_by_sequence_number(&anchor_msg_link, 4).await?;
-    if let MessageContent::SignedPacket {pk: _, public_payload: _, masked_payload } = &msg.body {
-        println!("  Msg => <{}>: {}", msg.link.msgid, String::from_utf8(masked_payload.0.to_vec())?);
+    if let MessageContent::SignedPacket {
+        pk: _,
+        public_payload: _,
+        masked_payload,
+    } = &msg.body
+    {
+        println!(
+            "  Msg => <{}>: {}",
+            msg.link.msgid,
+            String::from_utf8(masked_payload.0.to_vec())?
+        );
         assert_eq!(masked_payload.0, "Message 4".as_bytes().to_vec());
     } else {
         panic!("Packet found was not a signed packet from author")

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -117,7 +117,8 @@ async fn main_client() {
 
 fn new_seed() -> String {
     let alph9 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ9";
-    (0..10).map(|_| alph9.chars().nth(rand::thread_rng().gen_range(0, 27)).unwrap())
+    (0..10)
+        .map(|_| alph9.chars().nth(rand::thread_rng().gen_range(0, 27)).unwrap())
         .collect::<String>()
 }
 
@@ -131,6 +132,6 @@ async fn main() {
     match env::var("TRANSPORT").ok().as_deref() {
         Some("tangle") => main_client().await,
         Some("bucket") | None => main_pure().await,
-        Some(other) => panic!("Unexpected TRANSPORT '{}'", other)
+        Some(other) => panic!("Unexpected TRANSPORT '{}'", other),
     }
 }

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -97,11 +97,6 @@ async fn main_pure() {
 
 #[allow(dead_code)]
 async fn main_client() {
-    // Load or .env file, log message if we failed
-    if dotenv::dotenv().is_err() {
-        println!(".env file not found; copy and rename example.env to \".env\"");
-    };
-
     // Parse env vars with a fallback
     let node_url = env::var("URL").unwrap_or_else(|_| "https://chrysalis-nodes.iota.org".to_string());
 
@@ -128,6 +123,14 @@ fn new_seed() -> String {
 
 #[tokio::main]
 async fn main() {
-    main_pure().await;
-    //main_client().await;
+    // Load or .env file, log message if we failed
+    if dotenv::dotenv().is_err() {
+        println!(".env file not found; copy and rename example.env to \".env\"");
+    };
+
+    match env::var("TRANSPORT").ok().as_deref() {
+        Some("tangle") => main_client().await,
+        Some("bucket") | None => main_pure().await,
+        Some(other) => panic!("Unexpected TRANSPORT '{}'", other)
+    }
 }


### PR DESCRIPTION
# Description of change

This small PR introduces the possibility to select the transport used in the main Rust examples of the tool.

- by default, the examples run through the bucket transport
- `TRANSPORT=tangle` environment activates the Tangle transport
- `TRANSPORT=bucket` environment explicitly activates the bucket transport

This trivial change has its own PR because it also fixes some lint warnings and runs `cargo +nightly fmt` with a significant amount of noisy changes. 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

- [x] (cd examples && cargo +nightly fmt && cargo check && cargo clippy && cargo run)

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
