### PR TITLE
Correct `MessageLinkNotFound*` messages being crossed

### DIFF
--- a/iota-streams-app/src/transport/bucket.rs
+++ b/iota-streams-app/src/transport/bucket.rs
@@ -8,7 +8,7 @@ use iota_streams_core::{
         string::ToString,
         HashMap,
     },
-    Errors::MessageLinkNotFound,
+    Errors::MessageLinkNotFoundInBucket,
 };
 
 use iota_streams_core::{
@@ -70,7 +70,7 @@ where
         if let Some(msgs) = self.bucket.get(link) {
             Ok(msgs.clone())
         } else {
-            err!(MessageLinkNotFound(link.to_string()))
+            err!(MessageLinkNotFoundInBucket(link.to_string()))
         }
     }
 
@@ -80,7 +80,7 @@ where
             try_or!(msgs.is_empty(), MessageNotUnique(link.to_string())).unwrap();
             Ok(msg)
         } else {
-            err!(MessageLinkNotFound(link.to_string()))?
+            err!(MessageLinkNotFoundInBucket(link.to_string()))?
         }
     }
 }

--- a/iota-streams-app/src/transport/tangle/client.rs
+++ b/iota-streams-app/src/transport/tangle/client.rs
@@ -259,7 +259,7 @@ where
             try_or!(msgs.is_empty(), MessageNotUnique(link.to_string()))?;
             Ok(msg)
         } else {
-            err!(MessageLinkNotFound(link.to_string()))
+            err!(MessageLinkNotFoundInTangle(link.to_string()))
         }
     }
 }

--- a/iota-streams-core/src/errors/error_messages.rs
+++ b/iota-streams-core/src/errors/error_messages.rs
@@ -70,10 +70,12 @@ pub enum Errors {
     //////////
     /// More than one message found: with link {0}
     MessageNotUnique(String),
-    /// Message at link {0} not found in store
+    /// Message at link {0} not found in state store
     MessageLinkNotFound(String),
-    /// Message at link {0} not found in tangle
+    /// Message at link {0} not found in Tangle
     MessageLinkNotFoundInTangle(String),
+    /// Message at link {0} not found in Bucket transport
+    MessageLinkNotFoundInBucket(String),
     /// Transport object is already borrowed
     TransportNotAvailable,
 

--- a/iota-streams-core/src/errors/error_messages.rs
+++ b/iota-streams-core/src/errors/error_messages.rs
@@ -71,7 +71,7 @@ pub enum Errors {
     /// More than one message found: with link {0}
     MessageNotUnique(String),
     /// Message at link {0} not found in state store
-    MessageLinkNotFound(String),
+    MessageLinkNotFoundInStore(String),
     /// Message at link {0} not found in Tangle
     MessageLinkNotFoundInTangle(String),
     /// Message at link {0} not found in Bucket transport

--- a/iota-streams-ddml/src/link_store.rs
+++ b/iota-streams-ddml/src/link_store.rs
@@ -19,7 +19,7 @@ use iota_streams_core::{
     try_or,
     Errors::{
         GenericLinkNotFound,
-        MessageLinkNotFound,
+        MessageLinkNotFoundInStore,
     },
 };
 
@@ -120,7 +120,7 @@ where
 {
     type Info = Info;
     fn lookup(&self, link: &Link) -> Result<(Spongos<F>, Self::Info)> {
-        try_or!(self.link() == link, MessageLinkNotFound(link.to_string()))?;
+        try_or!(self.link() == link, MessageLinkNotFoundInStore(link.to_string()))?;
         Ok((self.spongos().into(), self.info().clone()))
     }
     fn update(&mut self, link: &Link, spongos: Spongos<F>, info: Self::Info) -> Result<()> {
@@ -173,7 +173,7 @@ where
     fn lookup(&self, link: &Link) -> Result<(Spongos<F>, Info)> {
         match self.map.get(link) {
             Some((inner, info)) => Ok((inner.into(), info.clone())),
-            None => err!(MessageLinkNotFound(link.to_string())),
+            None => err!(MessageLinkNotFoundInStore(link.to_string())),
         }
     }
 

--- a/iota-streams-ddml/src/link_store.rs
+++ b/iota-streams-ddml/src/link_store.rs
@@ -19,7 +19,7 @@ use iota_streams_core::{
     try_or,
     Errors::{
         GenericLinkNotFound,
-        MessageLinkNotFoundInTangle,
+        MessageLinkNotFound,
     },
 };
 
@@ -120,7 +120,7 @@ where
 {
     type Info = Info;
     fn lookup(&self, link: &Link) -> Result<(Spongos<F>, Self::Info)> {
-        try_or!(self.link() == link, MessageLinkNotFoundInTangle(link.to_string()))?;
+        try_or!(self.link() == link, MessageLinkNotFound(link.to_string()))?;
         Ok((self.spongos().into(), self.info().clone()))
     }
     fn update(&mut self, link: &Link, spongos: Spongos<F>, info: Self::Info) -> Result<()> {
@@ -173,7 +173,7 @@ where
     fn lookup(&self, link: &Link) -> Result<(Spongos<F>, Info)> {
         match self.map.get(link) {
             Some((inner, info)) => Ok((inner.into(), info.clone())),
-            None => err!(MessageLinkNotFoundInTangle(link.to_string())),
+            None => err!(MessageLinkNotFound(link.to_string())),
         }
     }
 


### PR DESCRIPTION
# Description of change

`MessageLinkNotFound` is meant for reporting that the link has not been found in
the state store. `MessageLinkNotFoundInTangle` is meant for reporting that the link
has not been found in the `Tangle` transport. Added `MessageLinkNotFoundInBucket`
for consistency.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)


## How the change has been tested

running wasm example

## Change checklist

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
