### PR TITLE
Don't allow subscription with existing user key

### DIFF
--- a/iota-streams-app-channels/src/api/user.rs
+++ b/iota-streams-app-channels/src/api/user.rs
@@ -417,9 +417,10 @@ where
     pub fn insert_subscriber(&mut self, pk: ed25519::PublicKey) -> Result<()> {
         let ref_link = self.appinst.as_ref().unwrap().rel().clone();
         match !self.key_store.contains(&pk.into()) {
-            true => self.key_store
+            true => self
+                .key_store
                 .insert_cursor(pk.into(), Cursor::new_at(ref_link, 0, SEQ_MESSAGE_NUM)),
-            false => err!(UserAlreadyRegistered(hex::encode(pk.as_bytes())))
+            false => err!(UserAlreadyRegistered(hex::encode(pk.as_bytes()))),
         }
     }
 

--- a/iota-streams-app-channels/src/api/user.rs
+++ b/iota-streams-app-channels/src/api/user.rs
@@ -415,12 +415,12 @@ where
     }
 
     pub fn insert_subscriber(&mut self, pk: ed25519::PublicKey) -> Result<()> {
-        let ref_link = self.appinst.as_ref().unwrap().rel().clone();
-        match !self.key_store.contains(&pk.into()) {
-            true => self
+        match (!self.key_store.contains(&pk.into()), &self.appinst) {
+            (_, None) => err!(UserNotRegistered),
+            (true, Some(ref_link)) => self
                 .key_store
-                .insert_cursor(pk.into(), Cursor::new_at(ref_link, 0, SEQ_MESSAGE_NUM)),
-            false => err!(UserAlreadyRegistered(hex::encode(pk.as_bytes()))),
+                .insert_cursor(pk.into(), Cursor::new_at(ref_link.rel().clone(), 0, SEQ_MESSAGE_NUM)),
+            (false, Some(_)) => err!(UserAlreadyRegistered(hex::encode(pk.as_bytes()))),
         }
     }
 

--- a/iota-streams-app-channels/src/api/user.rs
+++ b/iota-streams-app-channels/src/api/user.rs
@@ -416,8 +416,11 @@ where
 
     pub fn insert_subscriber(&mut self, pk: ed25519::PublicKey) -> Result<()> {
         let ref_link = self.appinst.as_ref().unwrap().rel().clone();
-        self.key_store
-            .insert_cursor(pk.into(), Cursor::new_at(ref_link, 0, SEQ_MESSAGE_NUM))
+        match !self.key_store.contains(&pk.into()) {
+            true => self.key_store
+                .insert_cursor(pk.into(), Cursor::new_at(ref_link, 0, SEQ_MESSAGE_NUM)),
+            false => err!(UserAlreadyRegistered(hex::encode(pk.as_bytes())))
+        }
     }
 
     /// Prepare Subscribe message.

--- a/iota-streams-app-channels/src/api/user.rs
+++ b/iota-streams-app-channels/src/api/user.rs
@@ -300,7 +300,7 @@ where
         if let Some(appinst) = &self.appinst {
             try_or!(
                 appinst == &preparsed.header.link,
-                UserAlreadyRegistered(appinst.base().to_string())
+                UserAlreadyRegistered(hex::encode(self.sig_kp.public), appinst.base().to_string())
             )?;
         }
 
@@ -420,7 +420,10 @@ where
             (true, Some(ref_link)) => self
                 .key_store
                 .insert_cursor(pk.into(), Cursor::new_at(ref_link.rel().clone(), 0, SEQ_MESSAGE_NUM)),
-            (false, Some(_)) => err!(UserAlreadyRegistered(hex::encode(pk.as_bytes()))),
+            (false, Some(ref_link)) => err!(UserAlreadyRegistered(
+                hex::encode(pk.as_bytes()),
+                ref_link.base().to_string()
+            )),
         }
     }
 

--- a/iota-streams-core/src/errors/error_messages.rs
+++ b/iota-streams-core/src/errors/error_messages.rs
@@ -136,7 +136,7 @@ pub enum Errors {
     //////////
     /// Cannot create a channel, user is already registered to channel {0}
     ChannelCreationFailure(String),
-    /// Cannot unwrap announcement message, already registered to channel {0}
+    /// Cannot unwrap message, user already registered to channel {0}
     UserAlreadyRegistered(String),
     /// User is not registered to a channel
     UserNotRegistered,

--- a/iota-streams-core/src/errors/error_messages.rs
+++ b/iota-streams-core/src/errors/error_messages.rs
@@ -136,8 +136,8 @@ pub enum Errors {
     //////////
     /// Cannot create a channel, user is already registered to channel {0}
     ChannelCreationFailure(String),
-    /// Cannot unwrap message, user already registered to channel {0}
-    UserAlreadyRegistered(String),
+    /// Cannot register new user {0}, user is already registered to channel {1}
+    UserAlreadyRegistered(String, String),
     /// User is not registered to a channel
     UserNotRegistered,
     /// Message application instance does not match user channel (expected: {0}, found: {1}


### PR DESCRIPTION
# Description of change
Stop `Author` from accepting `Subscribe` messages that are sent from a user with an already registered `Identifier`. Existing user states should not be overwritten. 

Fixes #164 

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested
- Existing examples and binding examples continue to pass (including `streams-examples` repo tests)
- Ran example from #159 and received an error for trying to subscribe with the same seed as author
- Modified example form #159 removing subscription process completes successfully

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
