### PR TITLE
Update recover and reset_state 

### DIFF
--- a/bindings/c/include/iota_streams/channels.h
+++ b/bindings/c/include/iota_streams/channels.h
@@ -149,6 +149,7 @@ extern err_t auth_fetch_prev_msg(unwrapped_message_t const **umsg, author_t *aut
 extern err_t auth_fetch_prev_msgs(unwrapped_messages_t const **umsgs, author_t *author, address_t const *address, size_t num_msgs);
 extern err_t auth_sync_state(unwrapped_messages_t const **umsgs, author_t *author);
 extern err_t auth_fetch_state(user_state_t const **state, author_t *author);
+extern err_t auth_reset_state(author_t *author);
 // Store Psk
 extern err_t auth_store_psk(psk_id_t const **pskid, author_t *author, char const *psk);
 extern err_t auth_remove_psk(author_t *author, char const *pskid);

--- a/bindings/c/include/iota_streams/channels.h
+++ b/bindings/c/include/iota_streams/channels.h
@@ -160,7 +160,6 @@ extern err_t auth_remove_psk(author_t *author, char const *pskid);
 /////////////
 typedef struct Subscriber subscriber_t;
 extern err_t sub_new(subscriber_t **sub, char const *seed, transport_t *transport);
-extern err_t sub_recover(subscriber_t **sub, char const *seed, address_t const *announcement, transport_t *transport);
 extern err_t sub_import(subscriber_t **sub, buffer_t buffer, char const *password, transport_t *transport);
 extern err_t sub_export(buffer_t *buf, subscriber_t const *subscriber, char const *password);
 extern void sub_drop(subscriber_t *);

--- a/bindings/c/main.c
+++ b/bindings/c/main.c
@@ -493,12 +493,12 @@ cleanup7:
     printf("  %s\n", !e ? "done" : "failed");
     if(e) goto cleanup8;
 
-      printf("Syncing author... ");
-      e = auth_sync_state(&sync_returns, recovered_auth);
-      printf("  %s\n", !e ? "done" : "failed");
-      if(e) goto cleanup8;
+    printf("Syncing author... ");
+    e = auth_sync_state(&sync_returns, recovered_auth);
+    printf("  %s\n", !e ? "done" : "failed");
+    if(e) goto cleanup8;
 
-      e = auth_fetch_state(&recovered_auth_state, recovered_auth);
+    e = auth_fetch_state(&recovered_auth_state, recovered_auth);
     if(e) goto cleanup8;
     e = auth_fetch_state(&original_auth_state, auth);
     if(e) goto cleanup8;

--- a/bindings/c/main.c
+++ b/bindings/c/main.c
@@ -486,13 +486,19 @@ cleanup7:
     address_t const *recovered_state_link = NULL;
     address_t const *original_state_link = NULL;
     unwrapped_messages_t const *message_returns = NULL;
+    unwrapped_messages_t const *sync_returns = NULL;
 
     printf("Recovering author... ");
     e = auth_recover(&recovered_auth, seed, ann_link, implementation_type, tsp);
     printf("  %s\n", !e ? "done" : "failed");
     if(e) goto cleanup8;
 
-    e = auth_fetch_state(&recovered_auth_state, recovered_auth);
+      printf("Syncing author... ");
+      e = auth_sync_state(&sync_returns, recovered_auth);
+      printf("  %s\n", !e ? "done" : "failed");
+      if(e) goto cleanup8;
+
+      e = auth_fetch_state(&recovered_auth_state, recovered_auth);
     if(e) goto cleanup8;
     e = auth_fetch_state(&original_auth_state, auth);
     if(e) goto cleanup8;
@@ -525,6 +531,7 @@ cleanup8:
     drop_user_state(recovered_auth_state);
     auth_drop(recovered_auth);
     drop_unwrapped_messages(message_returns);
+    drop_unwrapped_messages(sync_returns);
   }
   printf("\n");
   if(e) goto cleanup;

--- a/bindings/c/src/api/auth.rs
+++ b/bindings/c/src/api/auth.rs
@@ -467,6 +467,13 @@ pub unsafe extern "C" fn auth_fetch_state(state: *mut *const UserState, user: *m
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn auth_reset_state(user: *mut Author) -> Err {
+    user.as_mut().map_or(Err::NullArgument, |user| {
+        user.reset_state().map_or(Err::OperationFailed, |_| Err::Ok)
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn auth_store_psk(c_pskid: *mut *const PskId, c_user: *mut Author, c_psk_seed: *const c_char) -> Err {
     if c_psk_seed == null() {
         return Err::NullArgument;

--- a/bindings/c/src/api/sub.rs
+++ b/bindings/c/src/api/sub.rs
@@ -24,32 +24,6 @@ pub unsafe extern "C" fn sub_new(
     })
 }
 
-/// Recover an existing channel from seed and existing announcement message
-#[no_mangle]
-pub unsafe extern "C" fn sub_recover(
-    c_sub: *mut *mut Subscriber,
-    c_seed: *const c_char,
-    c_ann_address: *const Address,
-    transport: *mut TransportWrap,
-) -> Err {
-    if c_seed == null() {
-        return Err::NullArgument;
-    }
-
-    CStr::from_ptr(c_seed).to_str().map_or(Err::BadArgument, |seed| {
-        c_ann_address.as_ref().map_or(Err::NullArgument, |addr| {
-            transport.as_ref().map_or(Err::NullArgument, |tsp| {
-                c_sub.as_mut().map_or(Err::NullArgument, |sub| {
-                    run_async(Subscriber::recover(seed, addr, tsp.clone())).map_or(Err::OperationFailed, |user| {
-                        *sub = safe_into_mut_ptr(user);
-                        Err::Ok
-                    })
-                })
-            })
-        })
-    })
-}
-
 /// Import an Author instance from an encrypted binary array
 #[no_mangle]
 pub unsafe extern "C" fn sub_import(

--- a/bindings/wasm/src/author/authorw.rs
+++ b/bindings/wasm/src/author/authorw.rs
@@ -362,6 +362,11 @@ impl Author {
             .into_js_result()
     }
 
+    #[wasm_bindgen(catch)]
+    pub fn reset_state(self) -> Result<()> {
+        self.author.borrow_mut().reset_state().into_js_result()
+    }
+
     pub fn store_new_subscriber(&self, pk_str: String) -> Result<()> {
         public_key_from_string(&pk_str)
             .and_then(|pk| self.author.borrow_mut().store_new_subscriber(pk).into_js_result())

--- a/bindings/wasm/src/subscriber/subscriberw.rs
+++ b/bindings/wasm/src/subscriber/subscriberw.rs
@@ -65,19 +65,6 @@ impl Subscriber {
             .into_js_result()
     }
 
-    pub async fn recover(seed: String, ann_address: Address, options: SendOptions) -> Result<Subscriber> {
-        let mut client = ApiClient::new_from_url(&options.url());
-        client.set_send_options(options.into());
-        let transport = Rc::new(RefCell::new(client));
-
-        ApiSubscriber::recover(&seed, ann_address.as_inner(), transport)
-            .await
-            .map(|sub| Subscriber {
-                subscriber: Rc::new(RefCell::new(sub)),
-            })
-            .into_js_result()
-    }
-
     pub fn clone(&self) -> Subscriber {
         Subscriber {
             subscriber: self.subscriber.clone(),

--- a/documentation/docs/libraries/c/api_reference.md
+++ b/documentation/docs/libraries/c/api_reference.md
@@ -323,16 +323,6 @@ Generates a new Subscriber instance
 | transport       | [`transport_t *`](#TransportWrap)      | Transport Client Wrapper |
 **Returns:** Error code.
 
-#### sub_recover(sub, seed, announcement, transport): [err_t](#Err) 
-Recover a Subscriber instance using the announcement address link and seed.
-
-| Param           | Type                                   | Description              |
-| --------------- | -------------------------------------- | ------------------------ |
-| sub             | `subscriber_t *`                       | Placeholder for resulting Subscriber instance |
-| seed            | `char const *`                         | Unique user seed         |
-| announcement    | [`address_t const *`](#Address)        | Announcement link        |
-| transport       | [`transport_t *`](#TransportWrap)      | Transport Client Wrapper |
-**Returns:** Error code.
 
 #### sub_drop(user)
 Drop a Subscriber instance from memory.

--- a/documentation/docs/libraries/c/api_reference.md
+++ b/documentation/docs/libraries/c/api_reference.md
@@ -273,6 +273,14 @@ Fetch the current user state to see the latest links for each publisher
 | author          | `author_t *`                  | Author instance                     |
 **Returns:** Error code. 
 
+#### auth_reset_state(author): [err_t](#Err)
+Reset the mapping of known publisher states for the channel for retrieval of messages from scratch.
+
+| Param           | Type                          | Description                         |
+| --------------- | ----------------------------- | ----------------------------------- |
+| author          | `author_t *`                  | Author instance                     |
+**Returns:** Error code.
+
 #### auth_store_psk(pskid, author, psk): [err_t](#Err) 
 Stores a given Pre Shared Key (Psk) into the Author instance, returning a Pre Shared Key Id (PskId) 
 
@@ -592,6 +600,13 @@ Fetch the current subscriber state to see the latest links for each publisher
 | subscriber       | `subscriber_t *`             | Subscriber instance                 |
 **Returns:** Error code.
 
+#### sub_reset_state(subscriber): [err_t](#Err)
+Reset the mapping of known publisher states for the channel for retrieval of messages from scratch.
+
+| Param           | Type                          | Description                         |
+| --------------- | ----------------------------- | ----------------------------------- |
+| subscriber      | `subscriber_t *`              | Subscriber instance                 |
+**Returns:** Error code.
 
 #### sub_store_psk(pskid, subscriber, psk): [err_t](#Err) 
 Stores a given Pre Shared Key (Psk) into the Subscriber instance, returning a Pre Shared Key Id (PskId) 

--- a/documentation/docs/libraries/wasm/api_reference.md
+++ b/documentation/docs/libraries/wasm/api_reference.md
@@ -305,16 +305,6 @@ Export a Subscriber instance as an encrypted array using a given password
 | password        | `string`            | Key to encrypt            | 
 **Returns:** Binary array representing an encrypted state of the subscriber.
 
-#### recover(seed, ann_address, implementation, options): Subscriber
-Recover a Subscriber instance from scratch using the known startup configurations
-
-| Param           | Type                | Description               |
-| --------------- | ------------------- | ------------------------- |
-| seed            | `string`            | Unique user seed          |
-| ann_address     | [`Address`](#Address) | Announcement message address for fetching | 
-| options         | `SendOptions`       | Options for Client        |
-**Returns:** A recovered Subscriber instance for reading from and writing to a channel.
-
 #### clone(): Subscriber 
 Generate a copy of the Subscriber instance for consumption by asynchronous functions
 

--- a/documentation/docs/libraries/wasm/api_reference.md
+++ b/documentation/docs/libraries/wasm/api_reference.md
@@ -265,6 +265,13 @@ Removes a Subscriber from the Author instance using their ed25519 Public Key
 | --------------- | -------------------------------------- | ------------------------ |
 | pk              | String                                 | Public Key string of Subscriber |
 
+#### reset_state()
+Reset the mapping of known publisher states for the channel for retrieval of messages from scratch.
+
+| Param           | Type                | Description               |
+| --------------- | ------------------- | ------------------------- |
+
+
 ### Subscriber
 Additional user implementations of a Channel. Can publish and read from public branches, and 
 branches that have been restricted by keyload messages that contain their public key. 

--- a/examples/src/branching/recovery.rs
+++ b/examples/src/branching/recovery.rs
@@ -89,6 +89,7 @@ pub async fn example<T: Transport>(transport: T, channel_type: ChannelType, seed
 
     println!("\n\nTime to try to recover the instance...");
     let mut new_author = Author::recover(seed, &announcement_link, channel_type, transport).await?;
+    new_author.sync_state().await;
 
     let state = new_author.fetch_state()?;
     let old_state = author.fetch_state()?;

--- a/iota-streams-app-channels/src/api/tangle/author.rs
+++ b/iota-streams-app-channels/src/api/tangle/author.rs
@@ -143,6 +143,12 @@ impl<Trans> Author<Trans> {
         Ok(state)
     }
 
+    /// Resets the cursor state storage to allow an Author to retrieve all messages in a channel
+    /// from scratch
+    pub fn reset_state(&mut self) -> Result<()> {
+        self.user.reset_state()
+    }
+
     /// Serialize user state and encrypt it with password.
     ///
     ///   # Arguments

--- a/iota-streams-app-channels/src/api/tangle/author.rs
+++ b/iota-streams-app-channels/src/api/tangle/author.rs
@@ -187,7 +187,6 @@ impl<Trans: Transport + Clone> Author<Trans> {
         panic_if_not(retrieved.binary == ann.message);
 
         author.user.commit_wrapped(ann.wrapped, MsgInfo::Announce)?;
-        author.sync_state().await;
 
         Ok(author)
     }

--- a/iota-streams-app-channels/src/api/tangle/subscriber.rs
+++ b/iota-streams-app-channels/src/api/tangle/subscriber.rs
@@ -170,21 +170,6 @@ impl<Trans> Subscriber<Trans> {
 }
 
 impl<Trans: Transport + Clone> Subscriber<Trans> {
-    /// Generates a new Subscriber implementation from input. It then syncs state of the user from
-    /// the given announcement message link
-    ///
-    ///  # Arguements
-    /// * `seed` - A string slice representing the seed of the user [Characters: A-Z, 9]
-    /// * `announcement` - An existing announcement message link for processing
-    /// * `transport` - Transport object used for sending and receiving
-    pub async fn recover(seed: &str, announcement: &Address, transport: Trans) -> Result<Self> {
-        let mut subscriber = Subscriber::new(seed, transport);
-        subscriber.receive_announcement(announcement).await?;
-        subscriber.sync_state().await;
-
-        Ok(subscriber)
-    }
-
     /// Create and Send a Subscribe message to a Channel app instance.
     ///
     /// # Arguments

--- a/iota-streams-app-channels/src/api/tangle/user.rs
+++ b/iota-streams-app-channels/src/api/tangle/user.rs
@@ -132,9 +132,9 @@ impl<Trans> User<Trans> {
         self.user.fetch_state()
     }
 
-    /// Resets the cursor state storage to allow a Subscriber to retrieve all messages in a channel
+    /// Resets the cursor state storage to allow a User to retrieve all messages in a channel
     /// from scratch
-    /// [Subscriber]
+    /// [Author, Subscriber]
     pub fn reset_state(&mut self) -> Result<()> {
         self.user.reset_state()
     }

--- a/iota-streams-app-channels/src/api/user.rs
+++ b/iota-streams-app-channels/src/api/user.rs
@@ -262,6 +262,7 @@ where
                     key_store.insert_cursor(*id, Cursor::new_at(appinst.rel().clone(), 0, 2_u32))?;
                 }
                 self.key_store = key_store;
+                self.link_store = LS::default();
 
                 self.link_gen.reset(appinst.clone());
                 Ok(())


### PR DESCRIPTION
# Description of change
This PR makes the following changes: 
- Remove `recover()` from `Subscriber`
- Add `reset_state()` to `Author` 
- Remove `sync_state()` from `Author::recover()`
- Update examples and documents

Addresses #163 & #161

## Type of change
- Enhancement (a non-breaking change which adds functionality)
- Documentation Fix

## How the change has been tested
- All examples updated to reflect need for `sync_state()` following `recover()`
- Binding examples updated and tested as well

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
