### PR TITLE
Fix: Reverted back to iotaledger iota.rs repo.

### DIFF
--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -10,9 +10,8 @@ license = "MIT"
 [lib]
 crate-type = ["cdylib"]
 
-# TODO: Discover this:
-[package.metadata.wasm-pack.profile.release]
-wasm-opt = false
+[profile.release]
+opt-level = 's'
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -24,7 +23,7 @@ js-sys = "0.3.46"
 
 serde = { version = "1.0", features = ["derive"] }
 iota-streams = {path = "../../", default-features = false, features = ["tangle", "wasm-client"]}
-client-wasm = { git = "https://github.com/kwek20/iota.rs", branch  = "wasm-export", default-features = false }
+client-wasm = { git = "https://github.com/iotaledger/iota.rs", rev  = "ee19ec4", default-features = false }
 
 # Needed to specify the js/wasm feature for a sub-crate
 getrandom = {version = "0.2.2", features = ["js"]}

--- a/iota-streams-app/Cargo.toml
+++ b/iota-streams-app/Cargo.toml
@@ -38,7 +38,7 @@ hex = { version = "0.4", default-features = false, optional = false }
 futures = { version = "0.3.8", default-features = false, features = ["executor"], optional = true }
 
 # Dependencies for "client" feature
-iota-client = { git = "https://github.com/kwek20/iota.rs", branch  = "wasm-export", default-features = false, optional = true }
+iota-client = { git = "https://github.com/iotaledger/iota.rs", rev  = "ee19ec4", default-features = false, optional = true }
 num_cpus = { version = "1.10", optional = true }
 
 cstr_core = { version = "0.2.2", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
# Description of change

Reverted back to iotaledger iota.rs repo for our iota-client and client-wasm
Also added size optimiser for wasm

## Type of change
- Bug fix (a non-breaking change which fixes an issue)