### PR TITLE
Fix: Keep Announcement state in LinkStore

### DIFF
--- a/iota-streams-app-channels/src/api/user.rs
+++ b/iota-streams-app-channels/src/api/user.rs
@@ -262,7 +262,11 @@ where
                     key_store.insert_cursor(*id, Cursor::new_at(appinst.rel().clone(), 0, 2_u32))?;
                 }
                 self.key_store = key_store;
-                self.link_store = LS::default();
+
+                let mut link_store = LS::default();
+                let ann_state = self.link_store.lookup(appinst.rel())?;
+                link_store.update(appinst.rel(), ann_state.0, ann_state.1)?;
+                self.link_store = link_store;
 
                 self.link_gen.reset(appinst.clone());
                 Ok(())


### PR DESCRIPTION
# Description of change
`LinkStore` getting reset to default means that all states are removed including the Announcement message state. This PR makes it so that the announcement message state continues to persist in store after being reset. 

#183 

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested
- After resetting state, user was able to re-fetch messages and continue publishing to branch 

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
