### PR TITLE
Update streams/documentation/docs/libraries/wasm/getting_started.md

### DIFF
--- a/documentation/docs/libraries/wasm/getting_started.md
+++ b/documentation/docs/libraries/wasm/getting_started.md
@@ -25,5 +25,5 @@ let response = await author.clone().send_announce();
 
 let ann_link = response.link;
 
-console.log("Channel Announcement at: ", ann_link.to_string());
+console.log("Channel Announcement at: ", ann_link.toString());
 ```

--- a/documentation/docs/libraries/wasm/getting_started.md
+++ b/documentation/docs/libraries/wasm/getting_started.md
@@ -1,39 +1,31 @@
 # Getting Started
-The WASM bindings allow for you to build a Streams API for web applications and nodejs. 
-The streams instance underlying the bindings is built with the `wasm-client` flag to 
-ensure a compatible client interface using the `iota.rs iota-client` crate. 
-
 Before building anything you'll need to make sure you have `npm` installed on your 
 machine.
 
-To build the library, first make sure you're in the wasm directory:
-```cd bindings/wasm``` and run ```npm install``` to sync up your dependencies. 
+### Install the library
+To install the library, you could run:
 
-For building the nodejs compatible api, run:
-```bash
-npm run build:nodejs  <- Builds to node/streams_wasm
-```
-
-And for building the web compatible api, run:
-```bash 
-npm run build:web  <- Builds to web/streams_wasm
-```
+```npm i @iota/streams-wasm```
 
 
 ### Starting a Channel 
 Once the package has been built, you can pull it into a script file like so: 
 ```javascript
-const streams = require("./node/streams_wasm");
+const streams = require("@iota/streams/node/streams.js");
 
 let node = "https://chrysalis-nodes.iota.org/";
-// Options include: (node-url, depth, local pow, # of threads)
-let options = new streams.SendOptions(node, 3, true, 1);
 
-// Author generated with: (Seed, Options, Multi-branching flag)
-let auth = new streams.Author("Unique Seed Here", options, false);
+// Options include: (node-url, local pow)
+let options = new streams.SendOptions(node, true);
 
-// Response formatting: { link, sequence link, msg }
+let client = await new streams.ClientBuilder().node(node).build();
+
+let auth = streams.Author.fromClient(streams.StreamsClient.fromClient(client), "Unique Seed Here", streams.ChannelType.SingleBranch);
+
+// Response formatting: {link, sequence link, msg }
 let response = await auth.clone().send_announce();
-let ann_link = response.get_link();
+
+let ann_link = response.link;
+
 console.log("Channel Announcement at: ", ann_link.to_string());
 ```

--- a/documentation/docs/libraries/wasm/getting_started.md
+++ b/documentation/docs/libraries/wasm/getting_started.md
@@ -5,25 +5,23 @@ machine.
 ### Install the library
 To install the library, you could run:
 
-```npm i @iota/streams-wasm```
+```npm i @iota/streams```
 
 
 ### Starting a Channel 
 Once the package has been built, you can pull it into a script file like so: 
 ```javascript
-const streams = require("@iota/streams/node/streams.js");
+const streams = require("@iota/streams/node");
 
 let node = "https://chrysalis-nodes.iota.org/";
 
 // Options include: (node-url, local pow)
 let options = new streams.SendOptions(node, true);
 
-let client = await new streams.ClientBuilder().node(node).build();
-
-let auth = streams.Author.fromClient(streams.StreamsClient.fromClient(client), "Unique Seed Here", streams.ChannelType.SingleBranch);
+let author = new streams.Author("Unique Seed Here", options.clone(), streams.ChannelType.MultiBranch );
 
 // Response formatting: {link, sequence link, msg }
-let response = await auth.clone().send_announce();
+let response = await author.clone().send_announce();
 
 let ann_link = response.link;
 


### PR DESCRIPTION
1) new install method through npm (without the need anymore of clone the streams repo and build it manually)
2) get_link() method doesn't exist anymore, it was replaced by link attribute