### PR TITLE
Update streams/documentation/docs/libraries/wasm/examples.md

### DIFF
--- a/documentation/docs/libraries/wasm/examples.md
+++ b/documentation/docs/libraries/wasm/examples.md
@@ -19,7 +19,7 @@ let author = streams.Author.fromClient(streams.StreamsClient.fromClient(client),
 let response = await author.clone().send_announce();
 let ann_link = response.link;
 // Link used by subscribers to attach to instance
-console.log("Announced at: ", ann_link.to_string());
+console.log("Announced at: ", ann_link.toString());
 ```
 
 ### Subscriber Generation
@@ -36,7 +36,7 @@ Subscriber sends a subscription message:
 let response = sub.clone().send_subscribe(ann_link.copy());
 let sub_link = response.link;
 // Link to be provided to the Author for subscription
-console.log("Subscription link: ", sub_link.to_string());
+console.log("Subscription link: ", sub_link.toString());
 ```
 
 ### Author accepts and processes subscription: 
@@ -51,7 +51,7 @@ Author sends a keyload for all participants in the channel:
 let response = author.clone().send_keyload_for_everyone(ann_link.copy());
 let keyload_link = response.link;
 // Keyload message can now act as starting point for a protected branch
-console.log("Keyload link for everyone: ", keyload_link.to_string());
+console.log("Keyload link for everyone: ", keyload_link.toString());
 ``` 
 
 ### Keyload (case 2)
@@ -61,7 +61,7 @@ let response = author.clone().send_keyload(ann_link.copy
 (), [], ["SubA_PublicKey"]);
 let sub_A_keyload_link = response.link;
 // Keyload message can now act as starting point for a protected branch
-console.log("Keyload link for SubA: ", sub_A_keyload_link.to_string());
+console.log("Keyload link for SubA: ", sub_A_keyload_link.toString());
 ``` 
 
 ### Sending Messages
@@ -85,7 +85,7 @@ let response = subA.clone().send_signed_packet(
     masked_payload
 );
 let msg_link = response.link;
-console.log("New message sent by Sub A at: ", msg_link.to_string());
+console.log("New message sent by Sub A at: ", msg_link.toString());
 ```
 
 ### Message Fetching 

--- a/documentation/docs/libraries/wasm/examples.md
+++ b/documentation/docs/libraries/wasm/examples.md
@@ -5,16 +5,19 @@ The general API is simply an abstraction over the rust library, so the examples 
 
 ## Core Functionality
 
-### Author Generation
-Create an Author and generate a new channel:
+### Declare general setting
 ```javascript
 let node = "https://chrysalis-nodes.iota.org/";
-let options = new streams.SendOptions(node, 3, true, 1);
-let multi_branching = false;
-let auth = new streams.Author("Unique Seed", options, multi_branching);
+let options = new streams.SendOptions(node, true);
+let client = await new streams.ClientBuilder().node(node).build();
+```
 
-let response = await auth.clone().send_announce();
-let ann_link = response.get_link();
+### Author and Channel Generation
+Create an Author and generate a new channel:
+```javascript
+let author = streams.Author.fromClient(streams.StreamsClient.fromClient(client), "Unique Seed", streams.ChannelType.SingleBranch);
+let response = await author.clone().send_announce();
+let ann_link = response.link;
 // Link used by subscribers to attach to instance
 console.log("Announced at: ", ann_link.to_string());
 ```
@@ -22,40 +25,41 @@ console.log("Announced at: ", ann_link.to_string());
 ### Subscriber Generation
 Create a Subscriber and attach to a channel:
 ```javascript
-let node = "https://chrysalis-nodes.iota.org/";
-let options = new streams.SendOptions(node, 3, true, 1);
-let sub = new streams.Subscriber("Unique Seed", options);
-
-let ann_link = streams.Address.from_str("AnnouncementLink:Here");
-await sub.clone().receive_announcement();
+let sub = new streams.Subscriber("Unique Seed", options.clone());
+let ann_link = streams.Address.parse("Announcement_link_string:Here");
+await sub.clone().receive_announcement(ann_link.copy());
 ```
 
-### Subscription
+### Subscriber subscribes to channel
 Subscriber sends a subscription message:
 ```javascript
-let response = sub.clone().send_subscribe(ann_link);
-let sub_link = response.get_link();
+let response = sub.clone().send_subscribe(ann_link.copy());
+let sub_link = response.link;
 // Link to be provided to the Author for subscription
 console.log("Subscription link: ", sub_link.to_string());
 ```
-Author accepts and processes subscription: 
+
+### Author accepts and processes subscription: 
 ```javascript
-let sub_link = streams.Address.from_str("SubLink:Here");
-await author.clone().receive_subscribe(sub_link);
+let sub_link = streams.Address.parse("Sub_link_string:Here");
+await author.clone().receive_subscribe(sub_link.copy());
 ```
 
-### Keyload
+### Keyload (case 1)
 Author sends a keyload for all participants in the channel:
 ```javascript
-let response = author.clone().send_keyload_for_everyone(ann_link);
-let keyload_link = response.get_link();
+let response = author.clone().send_keyload_for_everyone(ann_link.copy());
+let keyload_link = response.link;
 // Keyload message can now act as starting point for a protected branch
 console.log("Keyload link for everyone: ", keyload_link.to_string());
 ``` 
+
+### Keyload (case 2)
 Author sends a keyload for just one subscriber in the channel:
 ```javascript
-let response = author.clone().send_keyload(ann_link, [], ["SubA_PublicKey"]);
-let sub_A_keyload_link = response.get_link();
+let response = author.clone().send_keyload(ann_link.copy
+(), [], ["SubA_PublicKey"]);
+let sub_A_keyload_link = response.link;
 // Keyload message can now act as starting point for a protected branch
 console.log("Keyload link for SubA: ", sub_A_keyload_link.to_string());
 ``` 
@@ -80,7 +84,7 @@ let response = subA.clone().send_signed_packet(
     public_payload,
     masked_payload
 );
-let msg_link = resposne.get_link();
+let msg_link = response.link;
 console.log("New message sent by Sub A at: ", msg_link.to_string());
 ```
 


### PR DESCRIPTION
1) added .copy() every time ann_link or sub_link is consumed
2) get_link() method doesn't exist anymore, it was replaced by link attribute