### PR TITLE
FIX - Docs - WASM Api Ref

### DIFF
--- a/documentation/docs/libraries/wasm/api_reference.md
+++ b/documentation/docs/libraries/wasm/api_reference.md
@@ -6,12 +6,13 @@ The API is spread out across three categories:
 - [Subscriber](#Subscriber)
 - [Types](#Types)
 
-<br/><br/>
+
 ## Author
 Main user implementation of a Channel. Generates the channel, processes subscriptions 
 and manages them. It can also send and fetch messages.
 
 #### new(seed, options, channel_type): Author 
+
 Generates an Author instance 
 
 | Param           | Type                | Description        |
@@ -22,8 +23,9 @@ Generates an Author instance
 
 **Returns:** An Author instance for administrating a channel.
 
-<br/><br/>
+
 #### from_client(client, seed, implementation): Author 
+
 Create an Author instance from a client
 
 | Param           | Type                | Description        |
@@ -34,8 +36,9 @@ Create an Author instance from a client
 
 **Returns:** An Author instance for administrating a channel.
 
-<br/><br/>
+
 #### import(client, bytes, password): Author 
+
 Import an Author instance from an encrypted binary array
 
 | Param           | Type                | Description               |
@@ -46,8 +49,9 @@ Import an Author instance from an encrypted binary array
 
 **Returns:** A recovered Author instance for administrating a channel.
 
-<br/><br/>
+
 #### export(password): Uint8Array 
+
 Export an Author instance as an encrypted array using a given password
 
 | Param           | Type                | Description               |
@@ -56,8 +60,9 @@ Export an Author instance as an encrypted array using a given password
 
 **Returns:** Binary array representing an encrypted state of the author.
 
-<br/><br/>
+
 #### recover(seed, ann_address, implementation, options): Author
+
 Recover an Author instance from scratch using the known startup configurations
 
 | Param           | Type                | Description               |
@@ -69,8 +74,9 @@ Recover an Author instance from scratch using the known startup configurations
 
 **Returns:** A recovered Author instance for administrating a channel.
 
-<br/><br/>
+
 #### clone(): Author 
+
 Generate a copy of the Author instance for consumption by asynchronous functions
 
 | Param           | Type                | Description               |
@@ -78,8 +84,9 @@ Generate a copy of the Author instance for consumption by asynchronous functions
 
 **Returns:** A consumable Author instance for functions.
 
-<br/><br/>
+
 #### channel_address(): string 
+
 Return the channel address of the channel instance. 
 
 | Param           | Type                | Description               |
@@ -87,8 +94,9 @@ Return the channel address of the channel instance.
 
 **Returns:** Channel Address for user generated channel.
 
-<br/><br/>
+
 #### announcementLink(): string
+
 Return the announcement link of the channel instance.
 
 | Param           | Type                | Description               |
@@ -96,8 +104,9 @@ Return the announcement link of the channel instance.
 
 **Returns:** Announcement Address for user generated channel.
 
-<br/><br/>
+
 #### is_multi_branching(): bool 
+
 Check if a channel type is single branching or multi branching. 
 
 | Param           | Type                | Description               |
@@ -105,8 +114,9 @@ Check if a channel type is single branching or multi branching.
 
 **Returns:** Boolean representing the channel type: false=single branch, true=multi branch.
 
-<br/><br/>
+
 #### get_public_key(): string 
+
 Retrieve the Author public key.
 
 | Param           | Type                | Description               |
@@ -114,8 +124,9 @@ Retrieve the Author public key.
 
 **Returns:** The Author public key in hex representation.
 
-<br/><br/>
-#### fetch_state(): Array<[UserState](#UserState)>
+
+#### fetch_state(): Array&lt;[UserState](#UserState)>
+
 Retrieve the currently known publisher states for the channel.
 
 | Param           | Type                | Description               |
@@ -123,9 +134,14 @@ Retrieve the currently known publisher states for the channel.
 
 **Returns:** An array of user state objects representing the currently known state of all publishers in the channel.
 
-<br/><br/>
-### The following functions require author.clone() to use, as they consume the instance 
+:::info
+
+The following functions require author.clone() to use, as they consume the instance 
+
+:::
+
 #### _async -_ send_announce(): [UserResponse](#UserResponse)
+
 Send an announcement message, initialising the channel 
 
 | Param           | Type                | Description               |
@@ -133,8 +149,9 @@ Send an announcement message, initialising the channel
 
 **Returns:** A User Response wrapper around the announcement message.
 
-<br/><br/>
+
 #### _async -_ send_keyload_for_everyone(link): [UserResponse](#UserResponse)
+
 Send a keyload message for all subscribed participants in the channel, linked to a previous message 
 (usually the announcement in a multi branch).
 
@@ -144,8 +161,9 @@ Send a keyload message for all subscribed participants in the channel, linked to
 
 **Returns:** A User Response wrapper around the keyload message.
 
-<br/><br/>
+
 #### _async -_ send_keyload(link, psk_ids, sig_pks): [UserResponse](#UserResponse)
+
 Send a keyload message for specified subscribers and pre shared keys in the channel, linked to a previous 
 message (usually the announcement in a multi branch).
 
@@ -157,8 +175,9 @@ message (usually the announcement in a multi branch).
 
 **Returns:** A User Response wrapper around the keyload message.
 
-<br/><br/>
+
 #### _async -_ send_tagged_packet(link, public_payload, masked_payload): [UserResponse](#UserResponse)
+
 Send a tagged packet message linked to a previous message (usually the announcement in a multi branch).
 
 | Param           | Type                          | Description                                   |
@@ -169,8 +188,9 @@ Send a tagged packet message linked to a previous message (usually the announcem
 
 **Returns:** A User Response wrapper around the tagged packet message.
 
-<br/><br/>
+
 #### _async -_ send_signed_packet(link, public_payload, masked_payload): [UserResponse](#UserResponse)
+
 Send a signed packet message linked to a previous message (usually the announcement in a multi branch).
 
 | Param           | Type                          | Description                                   |
@@ -181,24 +201,27 @@ Send a signed packet message linked to a previous message (usually the announcem
 
 **Returns:** A User Response wrapper around the signed packet message.
 
-<br/><br/>
+
 #### _async -_ receive_subscribe(link)
+
 Process a subscription message by its link.
 
 | Param           | Type                          | Description                         |
 | --------------- | ----------------------------- | ----------------------------------- |
 | link            | [`address`](#Address)         | Address of subscription message     |
 
-<br/><br/>
+
 #### _async -_ receive_unsubscribe(link)
+
 Process an unsubscription message by its link.
 
 | Param           | Type                          | Description                         |
 | --------------- | ----------------------------- | ----------------------------------- |
 | link            | [`address`](#Address)         | Address of unsubscription message   |
 
-<br/><br/>
+
 #### _async -_ receive_tagged_packet(link): [UserResponse](#UserResponse)
+
 Receive a tagged packet by its link.
 
 | Param           | Type                          | Description                         |
@@ -207,8 +230,9 @@ Receive a tagged packet by its link.
 
 **Returns:** A User Response wrapper around the tagged packet message.
 
-<br/><br/>
+
 #### _async -_ receive_signed_packet(link): [UserResponse](#UserResponse)
+
 Receive a signed packet by its link.
 
 | Param           | Type                          | Description                         |
@@ -217,8 +241,9 @@ Receive a signed packet by its link.
 
 **Returns:** A User Response wrapper around the signed packet message.
 
-<br/><br/>
+
 #### _async -_ receive_sequence(link): [Address](#Address)
+
 Receive a sequence message by its link, and return the address of the sequenced message. 
 
 | Param           | Type                          | Description                         |
@@ -227,8 +252,9 @@ Receive a sequence message by its link, and return the address of the sequenced 
 
 **Returns:** The address link of the sequenced message.
 
-<br/><br/>
+
 #### _async -_ receive_msg(link): [UserResponse](#UserResponse)
+
 Receive a message generically without knowing its type.
 
 | Param           | Type                          | Description                          |
@@ -237,8 +263,9 @@ Receive a message generically without knowing its type.
 
 **Returns:** A User Response wrapper around the retrieved message.
 
-<br/><br/>
+
 #### _async -_ receive_msg_by_sequence_number(anchor_link, msg_num): [UserResponse](#UserResponse)
+
 Receive a message by its msg number in an anchored single depth channel.
 
 | Param           | Type                          | Description                          |
@@ -248,16 +275,18 @@ Receive a message by its msg number in an anchored single depth channel.
 
 **Returns:** A User Response wrapper around the retrieved message.
 
-<br/><br/>
+
 #### _async -_ sync_state()
+
 Synchronise a publishers state prior to sending another message. Retrieves any other messages from the channel 
 to ensure the user state matches all other publishers.
 
 | Param           | Type                          | Description                         |
 | --------------- | ----------------------------- | ----------------------------------- |
 
-<br/><br/>
-#### _async -_ fetch_next_msgs(): Array<[UserResponse](#UserResponse)>
+
+#### _async -_ fetch_next_msgs(): Array&lt;[UserResponse](#UserResponse)>
+
 Fetch the next message sent by each publisher (empty array if none are present).
 
 | Param           | Type                          | Description                         |
@@ -265,8 +294,9 @@ Fetch the next message sent by each publisher (empty array if none are present).
 
 **Returns:** An array of User Response wrappers around the retrieved messages.
 
-<br/><br/>
+
 #### _async -_ fetch_prev_msg(link): [UserResponse](#UserResponse)
+
 Fetch the previous message sent before the provided message link.
 
 | Param           | Type                          | Description                         |
@@ -275,8 +305,9 @@ Fetch the previous message sent before the provided message link.
 
 **Returns:** A User Response wrapper around the retrieved message.
 
-<br/><br/>
-#### _async -_ fetch_prev_msgs(link, max): Array<[UserResponse](#UserResponse)>
+
+#### _async -_ fetch_prev_msgs(link, max): Array&lt;[UserResponse](#UserResponse)>
+
 Fetch a defined number of previous messages in a channel.
 
 | Param           | Type                          | Description                         |
@@ -286,8 +317,8 @@ Fetch a defined number of previous messages in a channel.
 
 **Returns:** An array of User Response wrappers around the retrieved messages.
 
-<br/><br/>
-#### _async -_ gen_next_msg_ids(): Array<[NextMsgId](#NextMsgId)>
+
+Array&lt;_async -_ gen_next_msg_ids(): Array&lt;[NextMsgId](#NextMsgId)>
 Fetch the next message sent by each publisher (empty array if none are present).
 
 | Param           | Type                          | Description                         |
@@ -295,8 +326,9 @@ Fetch the next message sent by each publisher (empty array if none are present).
 
 **Returns:** An array of NextMsgId wrappers for each publisher in the channel.
 
-<br/><br/>
+
 #### store_psk(psk): String 
+
 Store a Pre Shared Key (Psk) and retrieve the Pre Shared Key Id (PskId) for use in keyload messages 
 | Param           | Type                          | Description                         |
 | --------------- | ----------------------------- | ----------------------------------- |
@@ -305,44 +337,49 @@ Store a Pre Shared Key (Psk) and retrieve the Pre Shared Key Id (PskId) for use 
 
 **Returns:** A PskId String representing the Psk in store.
 
-<br/><br/>
+
 #### remove_psk(pskid)
+
 Removes a Pre Shared Key (Psk) from the Author instance using a Pre Shared Key Id (PskId)
 
 | Param           | Type                                   | Description              |
 | --------------- | -------------------------------------- | ------------------------ |
 | pskid           | String                                 | PskId string representing the Psk in store |
 
-<br/><br/>
+
 #### store_new_subscriber(pk)
+
 Store the ed25519 Public Key identifier of a predefined subscriber into the Author instance
 
 | Param           | Type                                   | Description              |
 | --------------- | -------------------------------------- | ------------------------ |
 | pk              | String                                  | Public Key string of Subscriber |
 
-<br/><br/>
+
 #### auth_remove_subscriber(pk)
+
 Removes a Subscriber from the Author instance using their ed25519 Public Key
 
 | Param           | Type                                   | Description              |
 | --------------- | -------------------------------------- | ------------------------ |
 | pk              | String                                 | Public Key string of Subscriber |
 
-<br/><br/>
+
 #### reset_state()
+
 Reset the mapping of known publisher states for the channel for retrieval of messages from scratch.
 
 | Param           | Type                | Description               |
 | --------------- | ------------------- | ------------------------- |
 
 
-<br/><br/>
+
 ## Subscriber
 Additional user implementations of a Channel. Can publish and read from public branches, and 
 branches that have been restricted by keyload messages that contain their public key. 
 
 #### new(seed, options): Subscriber 
+
 Generates a Subscriber instance 
 
 | Param           | Type                | Description        |
@@ -352,8 +389,9 @@ Generates a Subscriber instance
 
 **Returns:** A Subscriber instance.
 
-<br/><br/>
+
 #### from_client(client, seed): Subscriber 
+
 Create a Subscriber instance from a client
 
 | Param           | Type                | Description        |
@@ -363,8 +401,9 @@ Create a Subscriber instance from a client
 
 **Returns:** A Subscriber instance.
 
-<br/><br/>
+
 #### import(client, bytes, password): Subscriber 
+
 Import a Subscriber instance from an encrypted binary array
 
 | Param           | Type                | Description               |
@@ -375,8 +414,9 @@ Import a Subscriber instance from an encrypted binary array
 
 **Returns:** A recovered Subscriber instance.
 
-<br/><br/>
+
 #### export(password): Uint8Array 
+
 Export a Subscriber instance as an encrypted array using a given password
 
 | Param           | Type                | Description               |
@@ -385,8 +425,9 @@ Export a Subscriber instance as an encrypted array using a given password
 
 **Returns:** Binary array representing an encrypted state of the subscriber.
 
-<br/><br/>
+
 #### clone(): Subscriber 
+
 Generate a copy of the Subscriber instance for consumption by asynchronous functions
 
 | Param           | Type                | Description               |
@@ -394,8 +435,9 @@ Generate a copy of the Subscriber instance for consumption by asynchronous funct
 
 **Returns:** A consumable Subscriber instance for functions.
 
-<br/><br/>
+
 #### channel_address(): string 
+
 Return the channel address of the channel instance. 
 
 | Param           | Type                | Description               |
@@ -403,8 +445,9 @@ Return the channel address of the channel instance.
 
 **Returns:** Channel Address for user generated channel.
 
-<br/><br/>
+
 #### announcementLink(): string
+
 Return the announcement link of the channel instance.
 
 | Param           | Type                | Description               |
@@ -412,8 +455,9 @@ Return the announcement link of the channel instance.
 
 **Returns:** Announcement Address for user generated channel.
 
-<br/><br/>
+
 #### is_multi_branching(): bool 
+
 Check if a channel type is single branching or multi branching. 
 
 | Param           | Type                | Description               |
@@ -421,8 +465,9 @@ Check if a channel type is single branching or multi branching.
 
 **Returns:** Boolean representing the channel type: false=single branch, true=multi branch.
 
-<br/><br/>
+
 #### get_public_key(): string 
+
 Retrieve the Subscriber public key.
 
 | Param           | Type                | Description               |
@@ -430,8 +475,9 @@ Retrieve the Subscriber public key.
 
 **Returns:** The Subscriber public key in hex representation.
 
-<br/><br/>
+
 #### author_public_key(): string 
+
 Retrieve the Author public key. Errors if no channel is registered.
 
 | Param           | Type                | Description               |
@@ -439,8 +485,9 @@ Retrieve the Author public key. Errors if no channel is registered.
 
 **Returns:** The Subscriber public key in hex representation.
 
-<br/><br/>
+
 #### is_registered(): bool 
+
 Check if the subscriber instance has processed a channel announcement. 
 
 | Param           | Type                | Description               |
@@ -448,15 +495,17 @@ Check if the subscriber instance has processed a channel announcement.
 
 **Returns:** Boolean representing if the subscriber instance has processed a channel announcement correctly.
 
-<br/><br/>
+
 #### unregister() 
+
 Unregister a subscriber instance from a channel. 
 
 | Param           | Type                | Description               |
 | --------------- | ------------------- | ------------------------- |
 
-<br/><br/>
-#### fetch_state(): Array<[UserState](#UserState)>
+
+#### fetch_state(): Array&lt;[UserState](#UserState)>
+
 Retrieve the currently known publisher states for the channel.
 
 | Param           | Type                | Description               |
@@ -464,9 +513,14 @@ Retrieve the currently known publisher states for the channel.
 
 **Returns:** An array of user state objects representing the currently known state of all publishers in the channel.
 
-<br/><br/>
-### The following functions require subscriber.clone() to use, as they consume the instance 
+:::info
+
+The following functions require subscriber.clone() to use, as they consume the instance
+
+:::
+
 #### _async -_ send_subscribe(link): [UserResponse](#UserResponse)
+
 Send a subscription message attached to an announcement message link. 
 
 | Param           | Type                | Description                       |
@@ -475,8 +529,9 @@ Send a subscription message attached to an announcement message link.
 
 **Returns:** A User Response wrapper around the subscribe message.
 
-<br/><br/>
+
 #### _async -_ send_unsubscribe(link): [UserResponse](#UserResponse)
+
 Send an unsubscription message attached to the user subscription message link.
 
 | Param           | Type                | Description                       |
@@ -485,8 +540,9 @@ Send an unsubscription message attached to the user subscription message link.
 
 **Returns:** A User Response wrapper around the unsubscribe message.
 
-<br/><br/>
+
 #### _async -_ send_tagged_packet(link, public_payload, masked_payload): [UserResponse](#UserResponse)
+
 Send a tagged packet message linked to a previous message (usually the announcement in a multi branch).
 
 | Param           | Type                          | Description                                   |
@@ -497,8 +553,8 @@ Send a tagged packet message linked to a previous message (usually the announcem
 
 **Returns:** A User Response wrapper around the tagged packet message.
 
-<br/><br/>
 #### _async -_ send_signed_packet(link, public_payload, masked_payload): [UserResponse](#UserResponse)
+
 Send a signed packet message linked to a previous message (usually the announcement in a multi branch).
 
 | Param           | Type                          | Description                                   |
@@ -509,16 +565,18 @@ Send a signed packet message linked to a previous message (usually the announcem
 
 **Returns:** A User Response wrapper around the signed packet message.
 
-<br/><br/>
+
 #### _async -_ receive_announcement(link)
+
 Process an announcement message and register the channel.
 
 | Param           | Type                          | Description                         |
 | --------------- | ----------------------------- | ----------------------------------- |
 | link            | [`address`](#Address)         | Address of the announcement message |
 
-<br/><br/>
+
 #### _async -_ receive_keyload(link): bool
+
 Receive a keyload by its link and return whether the subscriber has access beyond it or not.
 
 | Param           | Type                          | Description                         |
@@ -527,8 +585,9 @@ Receive a keyload by its link and return whether the subscriber has access beyon
 
 **Returns:** Boolean representing access to the branch.
 
-<br/><br/>
+
 #### _async -_ receive_tagged_packet(link): [UserResponse](#UserResponse)
+
 Receive a tagged packet by its link.
 
 | Param           | Type                          | Description                         |
@@ -537,8 +596,9 @@ Receive a tagged packet by its link.
 
 **Returns:** A User Response wrapper around the tagged packet message.
 
-<br/><br/>
+
 #### _async -_ receive_signed_packet(link): [UserResponse](#UserResponse)
+
 Receive a signed packet by its link.
 
 | Param           | Type                          | Description                         |
@@ -547,8 +607,9 @@ Receive a signed packet by its link.
 
 **Returns:** A User Response wrapper around the signed packet message.
 
-<br/><br/>
+
 #### _async -_ receive_sequence(link): [Address](#Address)
+
 Receive a sequence message by its link, and return the address of the sequenced message. 
 
 | Param           | Type                          | Description                         |
@@ -557,8 +618,9 @@ Receive a sequence message by its link, and return the address of the sequenced 
 
 **Returns:** The address link of the sequenced message.
 
-<br/><br/>
+
 #### _async -_ receive_msg(link): [UserResponse](#UserResponse)
+
 Receive a message generically without knowing its type.
 
 | Param           | Type                          | Description                          |
@@ -567,8 +629,9 @@ Receive a message generically without knowing its type.
 
 **Returns:** A User Response wrapper around the retrieved message.
 
-<br/><br/>
+
 #### _async -_ receive_msg_by_sequence_number(anchor_link, msg_num): [UserResponse](#UserResponse)
+
 Receive a message by its msg number in an anchored single depth channel.
 
 | Param           | Type                          | Description                          |
@@ -578,16 +641,18 @@ Receive a message by its msg number in an anchored single depth channel.
 
 **Returns:** A User Response wrapper around the retrieved message.
 
-<br/><br/>
+
 #### _async -_ sync_state()
+
 Synchronise a publishers state prior to sending another message. Retrieves any other messages from the channel 
 to ensure the user state matches all other publishers.
 
 | Param           | Type                          | Description                         |
 | --------------- | ----------------------------- | ----------------------------------- |
 
-<br/><br/>
-#### _async -_ fetch_next_msgs(): Array<[UserResponse](#UserResponse)>
+
+#### _async -_ fetch_next_msgs(): Array&lt;[UserResponse](#UserResponse)>
+
 Fetch the next message sent by each publisher (empty array if none are present).
 
 | Param           | Type                          | Description                         |
@@ -595,8 +660,9 @@ Fetch the next message sent by each publisher (empty array if none are present).
 
 **Returns:** An array of User Response wrappers around the retrieved messages.
 
-<br/><br/>
+
 #### _async -_ fetch_prev_msg(link): [UserResponse](#UserResponse)
+
 Fetch the previous message sent before the provided message link.
 
 | Param           | Type                          | Description                         |
@@ -605,8 +671,9 @@ Fetch the previous message sent before the provided message link.
 
 **Returns:** A User Response wrapper around the retrieved message.
 
-<br/><br/>
-#### _async -_ fetch_prev_msgs(link, max): Array<[UserResponse](#UserResponse)>
+
+#### _async -_ fetch_prev_msgs(link, max): Array&lt;[UserResponse](#UserResponse)>
+
 Fetch a defined number of previous messages in a channel.
 
 | Param           | Type                          | Description                         |
@@ -616,8 +683,9 @@ Fetch a defined number of previous messages in a channel.
 
 **Returns:** An array of User Response wrappers around the retrieved messages.
 
-<br/><br/>
+
 #### store_psk(psk): String 
+
 Store a Pre Shared Key (Psk) and retrieve the Pre Shared Key Id (PskId) for use in keyload messages 
 | Param           | Type                          | Description                         |
 | --------------- | ----------------------------- | ----------------------------------- |
@@ -625,38 +693,41 @@ Store a Pre Shared Key (Psk) and retrieve the Pre Shared Key Id (PskId) for use 
 
 **Returns:** A PskId String representing the Psk in store.
 
-<br/><br/>
+
 #### remove_psk(pskid)
+
 Removes a Pre Shared Key (Psk) from the Author instance using a Pre Shared Key Id (PskId)
 
 | Param           | Type                                   | Description              |
 | --------------- | -------------------------------------- | ------------------------ |
 | pskid           | String                                 | PskId string representing the Psk in store |
 
-<br/><br/>
+
 #### reset_state()
+
 Reset the mapping of known publisher states for the channel for retrieval of messages from scratch.
 
 | Param           | Type                | Description               |
 | --------------- | ------------------- | ------------------------- |
 
-<br/><br/>
+
 ## Types
 Generic Types and Primitives used in Wasm API:
-- [Client](#Client)
-- [SendOptions](#SendOptions)
-- [UserResponse](#UserResponse)
-- [Address](#Address)
-- [Message](#Message)
-- [NextMsgId](#NextMsgId)
-- [Cursor](#Cursor)
-- [UserState](#UserState)
+- [Client](#client)
+- [SendOptions](#sendoptions)
+- [UserResponse](#userresponse)
+- [Address](#address)
+- [Message](#message)
+- [NextMsgId](#nextmsgid)
+- [Cursor](#cursor)
+- [UserState](#userstate)
 
-<br/><br/>
 ### Client 
+
 Transport client for interacting with an Iota node.
 
 #### new(node, options): Client
+
 | Param           | Type                | Description        |
 | --------------- | ------------------- | ------------------ |
 | node            | `string`            | A node URL         |
@@ -664,11 +735,12 @@ Transport client for interacting with an Iota node.
 
 **Returns:** A client instance.
 
-<br/><br/>
 ### SendOptions
+
 Options for a transport client
 
 #### new(url, depth, local_pow, threads): SendOptions
+
 Create a new set of Send Options for the client
 
 | Param     | Type                 | Description                  |
@@ -678,11 +750,12 @@ Create a new set of Send Options for the client
 
 **Returns:** Send Options for a client instance.
 
-<br/><br/>
 ### UserResponse
+
 Response structure containing the details of a sent or retrieved message 
 
 #### new(link, seq_link, message): UserResponse
+
 Create a new User Response from the return of the rust api for sending and receiving messages.
 
 | Param     | Type                  | Description                                  |
@@ -693,8 +766,9 @@ Create a new User Response from the return of the rust api for sending and recei
 
 **Returns:** User Response containing links and message.
 
-<br/><br/>
+
 #### from_strings(link, seq_link, message): UserResponse
+
 Create a new User Response from the return of the rust api for sending and receiving messages, 
 using strings for the link and seq_link inputs.
 
@@ -706,8 +780,9 @@ using strings for the link and seq_link inputs.
 
 **Returns:** User Response containing links and message.
 
-<br/><br/>
+
 #### copy(): UserResponse
+
 Create a copy of the User Response
 
 | Param     | Type                  | Description                                  |
@@ -715,8 +790,9 @@ Create a copy of the User Response
 
 **Returns:** A copy of the User Response.
 
-<br/><br/>
+
 #### get_seq_link(): [Address](#Address)
+
 Fetch the sequence link of the retrieved or sent message (Default if there is none).
 
 | Param     | Type                  | Description                                  |
@@ -724,8 +800,9 @@ Fetch the sequence link of the retrieved or sent message (Default if there is no
 
 **Returns:** The link for the retrieved or sent message.
 
-<br/><br/>
+
 #### get_message(): [Message](#Message)
+
 Fetch the retrieved or sent message (Default if there is none).
 
 | Param     | Type                  | Description                                  |
@@ -733,37 +810,42 @@ Fetch the retrieved or sent message (Default if there is none).
 
 **Returns:** The retrieved or sent message.
 
-<br/><br/>
 ### Address
+
 Streams Address containing the Application Instance and Message Id 
 
 #### set_addr_id(addr_id)
+
 | Param     | Type                  | Description                                  |
 | --------- | --------------------- | -------------------------------------------- |
 | addr_id   | `string`              | Application instance of the channel          |
 
-<br/><br/>
+
 #### addr_id(): string
+
 | Param     | Type                  | Description                                  |
 | --------- | --------------------- | -------------------------------------------- |
 
 **Returns:** The Channel Identifier/Application Instance of the Address
 
-<br/><br/>
+
 #### set_msg_id(msg_id)
+
 | Param     | Type                  | Description                                  |
 | --------- | --------------------- | -------------------------------------------- |
 | msg_id    | `string`              | Message Identifier of the message itself     |
 
-<br/><br/>
+
 #### msg_id(): string
+
 | Param     | Type                  | Description                                  |
 | --------- | --------------------- | -------------------------------------------- |
 
 **Returns:** The Message Identifier of the Address
 
-<br/><br/>
+
 #### from_string(address): Address
+
 Make an Address object from a string representation
  
 | Param     | Type                  | Description                                  |
@@ -772,8 +854,9 @@ Make an Address object from a string representation
 
 **Returns:** An Address object
 
-<br/><br/>
+
 #### to_string(): string
+
 Return a string representation of an Address object
 
 | Param     | Type                  | Description                                  |
@@ -781,11 +864,12 @@ Return a string representation of an Address object
 
 **Returns:** String representation of an Address
 
-<br/><br/>
 ### Message 
+
 A wrapper for a Rust Streams Message
 
 #### default(): Message 
+
 Generate a default message object
 
 | Param     | Type                  | Description                                  |
@@ -793,8 +877,9 @@ Generate a default message object
 
 **Returns:** A default Message object
 
-<br/><br/>
+
 #### new(pk, public_payload, masked_payload): Message
+
 Make a Message object from the optional pk and the public and masked payloads
  
 | Param          | Type                 | Description                          |
@@ -805,8 +890,9 @@ Make a Message object from the optional pk and the public and masked payloads
 
 **Returns:** A Message wrapper object
 
-<br/><br/>
+
 #### get_public_key(): string
+
 Fetch the public key of the Message sender (default if none is presented)
 
 | Param     | Type                  | Description                                  |
@@ -814,8 +900,9 @@ Fetch the public key of the Message sender (default if none is presented)
 
 **Returns:** Public key in hex representation of the sender of the message 
 
-<br/><br/>
+
 #### get_public_payload(): Uint8Array
+
 Fetch the public payload of the Message sender
 
 | Param     | Type                  | Description                                  |
@@ -823,8 +910,9 @@ Fetch the public payload of the Message sender
 
 **Returns:** Public payload byte array 
 
-<br/><br/>
+
 #### get_masked_payload(): Uint8Array
+
 Fetch the masked payload of the Message sender
 
 | Param     | Type                  | Description                                  |
@@ -832,11 +920,12 @@ Fetch the masked payload of the Message sender
 
 **Returns:** Masked payload byte array 
 
-<br/><br/>
 ### NextMsgId 
+
 A wrapper for a Rust NextMsgId structure
 
 #### new(identifier, msgid): NextMsgId
+
 Make a NextMsgId object from the identifier and expected next message address
  
 | Param          | Type                  | Description                          |
@@ -846,8 +935,9 @@ Make a NextMsgId object from the identifier and expected next message address
 
 **Returns:** A NextMsgId wrapper object
 
-<br/><br/>
+
 #### get_identifier(): string
+
 Fetch the identifier of the Message sender
 
 | Param     | Type                  | Description                                  |
@@ -855,11 +945,12 @@ Fetch the identifier of the Message sender
 
 **Returns:** Identifier in hex representation of the sender of the message 
 
-<br/><br/>
 ### PskIds
+
 An array of PskIds representing the Pre Shared Keys that are used in keyload messages.
 
 #### new(): PskIds 
+
 Generate a new array of PskIds
 
 | Param     | Type                  | Description                                  |
@@ -867,16 +958,18 @@ Generate a new array of PskIds
 
 **Returns:** Empty array for PskIds to be added to
 
-<br/><br/>
+
 #### add(pskid) 
+
 Add a pskid 
 
 | Param     | Type                  | Description                                    |
 | --------- | --------------------- | ---------------------------------------------- | 
 | pskid     | `string`              | PskId string representation [must be 32 bytes] |
 
-<br/><br/>
+
 #### get_ids(): Array&lt;string>
+
 Fetch PskIds in string formatting
 
 | Param     | Type                  | Description                                  |
@@ -884,11 +977,12 @@ Fetch PskIds in string formatting
 
 **Returns:** Array of PskIds in string formatting
 
-<br/><br/>
 ### PublicKeys
+
 An array of PublicKeys representing a set of users.
 
 #### new(): PublicKeys 
+
 Generate a new array of PublicKeys
 
 | Param     | Type                  | Description                                  |
@@ -896,16 +990,18 @@ Generate a new array of PublicKeys
 
 **Returns:** Empty array for PublicKeys to be added to
 
-<br/><br/>
+
 #### add(pk) 
+
 Add a public key string
 
 | Param     | Type                  | Description                                    |
 | --------- | --------------------- | ---------------------------------------------- | 
 | pk        | `string`              | Public Key string representation               |
 
-<br/><br/>
+
 #### get_pks(): Array&lt;string>
+
 Fetch Public Keys in string formatting
 
 | Param     | Type                  | Description                                  |
@@ -913,18 +1009,19 @@ Fetch Public Keys in string formatting
 
 **Returns:** Array of Public Keys in string formatting
 
-<br/><br/>
 ### Cursor
+
 The publishing state of a particular publisher (The latest sequenced message known for that publisher). This includes:
 - The latest published message link
 - The sequence state number of the publisher
 - A branch number for that latest posted message 
 
-<br/><br/>
 ### UserState
+
 A wrapper around a publisher state. Includes the identifier and [cursor](#Cursor) of the publisher
 
 #### get_identifier()
+
 Get the public key of the user from the state
 
 | Param     | Type                  | Description                                  |
@@ -932,8 +1029,9 @@ Get the public key of the user from the state
 
 **Returns:** Identifier of publisher in hex formatting
 
-<br/><br/>
+
 #### get_link() 
+
 Get the link from the internal cursor object 
 
 | Param     | Type                  | Description                                  |
@@ -941,8 +1039,9 @@ Get the link from the internal cursor object
 
 **Returns:** The latest published message link 
 
-<br/><br/>
+
 #### get_seq_no()
+
 Get the sequence state number from the internal cursor object 
 
 | Param     | Type                  | Description                                  |
@@ -950,8 +1049,9 @@ Get the sequence state number from the internal cursor object
 
 **Returns:** The latest sequence state number of the publisher 
 
-<br/><br/>
+
 #### get_branch_no()
+
 Get the branch state number from the internal cursor object
 
 | Param     | Type                  | Description                                  |


### PR DESCRIPTION
# Description of change

The wasm api ref is causing a [compilation error](https://github.com/lucas-tortora/iota-wiki/runs/4361120497?check_suite_focus=true) which prevents the wiki from deploying.  

* Changed Array<.*> for Array$lt;.*> as the unclosed tags cause a syntax error in the docursaurus compiler
* Fixed titles
* Removed br tags which were not needed

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Documentation Fix

## How the change has been tested

Wiki was built locally

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
