### PR TITLE
Feat/add message type in wasm messages

### DIFF
--- a/bindings/wasm/examples/node.js
+++ b/bindings/wasm/examples/node.js
@@ -86,6 +86,7 @@ async function main() {
   console.log("\nAuthor fetching next messages");
   for (const msg of await auth.clone().fetchNextMsgs()) {
     console.log("Found a message...");
+    console.log("Message type: ", msg.messageType)
     console.log(
       "Public: ",
       from_bytes(msg.message.get_public_payload()),

--- a/bindings/wasm/examples/node.ts
+++ b/bindings/wasm/examples/node.ts
@@ -86,6 +86,7 @@ async function main() {
     console.log("\nAuthor fetching next messages");
     for (const msg of await auth.clone().fetchNextMsgs()) {
         console.log("Found a message...");
+        console.log("Message type: ", msg.messageType)
         console.log(
             "Public: ",
             from_bytes(msg.message.get_public_payload()),

--- a/bindings/wasm/src/author/authorw.rs
+++ b/bindings/wasm/src/author/authorw.rs
@@ -435,7 +435,7 @@ impl Author {
 
     pub fn remove_psk(&self, pskid_str: String) -> Result<()> {
         pskid_from_hex_str(&pskid_str)
-            .and_then(|pskid| self.author.borrow_mut().remove_psk(pskid).into())
+            .and_then(|pskid| self.author.borrow_mut().remove_psk(pskid))
             .into_js_result()
     }
 }

--- a/bindings/wasm/src/author/authorw.rs
+++ b/bindings/wasm/src/author/authorw.rs
@@ -155,7 +155,7 @@ impl Author {
             .borrow_mut()
             .send_announce()
             .await
-            .map(|addr| UserResponse::new(addr.into(), None, None))
+            .map(|addr| UserResponse::new(addr.into(), None, MessageType::Announce, None))
             .into_js_result()
     }
 
@@ -165,7 +165,9 @@ impl Author {
             .borrow_mut()
             .send_keyload_for_everyone(link.as_inner())
             .await
-            .map(|(link, seq_link)| UserResponse::new(link.into(), seq_link.map(Into::into), None))
+            .map(|(link, seq_link)| {
+                UserResponse::new(link.into(), seq_link.map(Into::into), MessageType::Keyload, None)
+            })
             .into_js_result()
     }
 
@@ -178,7 +180,9 @@ impl Author {
             .borrow_mut()
             .send_keyload(link.as_inner(), &identifiers)
             .await
-            .map(|(link, seq_link)| UserResponse::new(link.into(), seq_link.map(Into::into), None))
+            .map(|(link, seq_link)| {
+                UserResponse::new(link.into(), seq_link.map(Into::into), MessageType::Keyload, None)
+            })
             .into_js_result()
     }
 
@@ -197,7 +201,9 @@ impl Author {
                 &Bytes(masked_payload.clone()),
             )
             .await
-            .map(|(link, seq_link)| UserResponse::new(link.into(), seq_link.map(Into::into), None))
+            .map(|(link, seq_link)| {
+                UserResponse::new(link.into(), seq_link.map(Into::into), MessageType::TaggedPacket, None)
+            })
             .into_js_result()
     }
 
@@ -212,7 +218,9 @@ impl Author {
             .borrow_mut()
             .send_signed_packet(link.as_inner(), &Bytes(public_payload), &Bytes(masked_payload))
             .await
-            .map(|(link, seq_link)| UserResponse::new(link.into(), seq_link.map(Into::into), None))
+            .map(|(link, seq_link)| {
+                UserResponse::new(link.into(), seq_link.map(Into::into), MessageType::SignedPacket, None)
+            })
             .into_js_result()
     }
 
@@ -241,7 +249,12 @@ impl Author {
             .receive_tagged_packet(link.as_inner())
             .await
             .map(|(pub_bytes, masked_bytes)| {
-                UserResponse::new(link, None, Some(Message::new(None, pub_bytes.0, masked_bytes.0)))
+                UserResponse::new(
+                    link,
+                    None,
+                    MessageType::TaggedPacket,
+                    Some(Message::new(None, pub_bytes.0, masked_bytes.0)),
+                )
             })
             .into_js_result()
     }
@@ -256,6 +269,7 @@ impl Author {
                 UserResponse::new(
                     link,
                     None,
+                    MessageType::SignedPacket,
                     Some(Message::new(
                         Some(public_key_to_string(&pk)),
                         pub_bytes.0,

--- a/bindings/wasm/src/subscriber/subscriberw.rs
+++ b/bindings/wasm/src/subscriber/subscriberw.rs
@@ -165,7 +165,12 @@ impl Subscriber {
             .receive_tagged_packet(link.as_inner())
             .await
             .map(|(pub_bytes, masked_bytes)| {
-                UserResponse::new(link, None, Some(Message::new(None, pub_bytes.0, masked_bytes.0)))
+                UserResponse::new(
+                    link,
+                    None,
+                    MessageType::TaggedPacket,
+                    Some(Message::new(None, pub_bytes.0, masked_bytes.0)),
+                )
             })
             .into_js_result()
     }
@@ -180,6 +185,7 @@ impl Subscriber {
                 UserResponse::new(
                     link,
                     None,
+                    MessageType::SignedPacket,
                     Some(Message::new(
                         Some(public_key_to_string(&pk)),
                         pub_bytes.0,
@@ -224,7 +230,7 @@ impl Subscriber {
             .borrow_mut()
             .send_subscribe(link.as_inner())
             .await
-            .map(|link| UserResponse::new(link.into(), None, None))
+            .map(|link| UserResponse::new(link.into(), None, MessageType::Subscribe, None))
             .into_js_result()
     }
 
@@ -234,7 +240,7 @@ impl Subscriber {
             .borrow_mut()
             .send_unsubscribe(link.as_inner())
             .await
-            .map(|link| UserResponse::new(link.into(), None, None))
+            .map(|link| UserResponse::new(link.into(), None, MessageType::Unsubscribe, None))
             .into_js_result()
     }
 
@@ -249,7 +255,9 @@ impl Subscriber {
             .borrow_mut()
             .send_tagged_packet(link.as_inner(), &Bytes(public_payload), &Bytes(masked_payload))
             .await
-            .map(|(link, seq_link)| UserResponse::new(link.into(), seq_link.map(Into::into), None))
+            .map(|(link, seq_link)| {
+                UserResponse::new(link.into(), seq_link.map(Into::into), MessageType::TaggedPacket, None)
+            })
             .into_js_result()
     }
 
@@ -264,7 +272,9 @@ impl Subscriber {
             .borrow_mut()
             .send_signed_packet(link.as_inner(), &Bytes(public_payload), &Bytes(masked_payload))
             .await
-            .map(|(link, seq_link)| UserResponse::new(link.into(), seq_link.map(Into::into), None))
+            .map(|(link, seq_link)| {
+                UserResponse::new(link.into(), seq_link.map(Into::into), MessageType::SignedPacket, None)
+            })
             .into_js_result()
     }
 

--- a/bindings/wasm/src/subscriber/subscriberw.rs
+++ b/bindings/wasm/src/subscriber/subscriberw.rs
@@ -400,7 +400,7 @@ impl Subscriber {
 
     pub fn remove_psk(&self, pskid_str: String) -> Result<()> {
         pskid_from_hex_str(&pskid_str)
-            .and_then(|pskid| self.subscriber.borrow_mut().remove_psk(pskid).into())
+            .and_then(|pskid| self.subscriber.borrow_mut().remove_psk(pskid))
             .into_js_result()
     }
 }

--- a/bindings/wasm/src/types/mod.rs
+++ b/bindings/wasm/src/types/mod.rs
@@ -322,13 +322,24 @@ pub fn get_message_content(msg: UnwrappedMessage) -> UserResponse {
         } => UserResponse::new(
             msg.link.into(),
             None,
+            MessageType::SignedPacket,
             Some(Message::new(Some(hex::encode(pk.to_bytes())), p.0, m.0)),
         ),
         MessageContent::TaggedPacket {
             public_payload: p,
             masked_payload: m,
-        } => UserResponse::new(msg.link.into(), None, Some(Message::new(None, p.0, m.0))),
-        _ => UserResponse::new(msg.link.into(), None, None),
+        } => UserResponse::new(
+            msg.link.into(),
+            None,
+            MessageType::TaggedPacket,
+            Some(Message::new(None, p.0, m.0)),
+        ),
+        MessageContent::Keyload => UserResponse::new(msg.link.into(), None, MessageType::Keyload, None),
+        MessageContent::Announce => UserResponse::new(msg.link.into(), None, MessageType::Announce, None),
+        MessageContent::Subscribe => UserResponse::new(msg.link.into(), None, MessageType::Subscribe, None),
+        MessageContent::Unsubscribe => UserResponse::new(msg.link.into(), None, MessageType::Unsubscribe, None),
+        MessageContent::Unreadable(..) => UserResponse::new(msg.link.into(), None, MessageType::Unreadable, None),
+        MessageContent::Sequence => UserResponse::new(msg.link.into(), None, MessageType::Sequence, None),
     }
 }
 
@@ -361,6 +372,7 @@ impl From<ChannelType> for ApiChannelType {
 pub struct UserResponse {
     link: Address,
     seq_link: Option<Address>,
+    message_type: MessageType,
     message: Option<Message>,
 }
 
@@ -524,6 +536,19 @@ mod public_keys_tests {
 }
 
 #[wasm_bindgen]
+#[derive(Clone, Copy)]
+pub enum MessageType {
+    SignedPacket = "signedPacket",
+    TaggedPacket = "taggedPacket",
+    Subscribe = "subscribe",
+    Unsubscribe = "unsubscribe",
+    Keyload = "keyload",
+    Announce = "announce",
+    Unreadable = "unreadable",
+    Sequence = "sequence",
+}
+
+#[wasm_bindgen]
 #[derive(Clone)]
 pub struct Message {
     identifier: Option<String>,
@@ -533,10 +558,6 @@ pub struct Message {
 
 #[wasm_bindgen]
 impl Message {
-    pub fn default() -> Message {
-        Self::new(None, Vec::new(), Vec::new())
-    }
-
     pub fn new(identifier: Option<String>, public_payload: Vec<u8>, masked_payload: Vec<u8>) -> Message {
         Message {
             identifier,
@@ -567,18 +588,25 @@ impl NextMsgAddress {
 
 #[wasm_bindgen]
 impl UserResponse {
-    pub fn new(link: Address, seq_link: Option<Address>, message: Option<Message>) -> Self {
+    pub fn new(link: Address, seq_link: Option<Address>, message_type: MessageType, message: Option<Message>) -> Self {
         UserResponse {
             link,
             seq_link,
+            message_type,
             message,
         }
     }
 
     #[wasm_bindgen(js_name = "fromStrings")]
-    pub fn from_strings(link: String, seq_link: Option<String>, message: Option<Message>) -> Result<UserResponse> {
+    pub fn from_strings(
+        link: String,
+        message_type: MessageType,
+        seq_link: Option<String>,
+        message: Option<Message>,
+    ) -> Result<UserResponse> {
         Ok(UserResponse {
             link: Address::from_str(&link).into_js_result()?,
+            message_type,
             seq_link: seq_link
                 .as_deref()
                 .map(Address::from_str)
@@ -600,6 +628,11 @@ impl UserResponse {
     #[wasm_bindgen(getter, js_name = "seqLink")]
     pub fn seq_link(&self) -> Option<Address> {
         self.seq_link
+    }
+
+    #[wasm_bindgen(getter, js_name = "messageType")]
+    pub fn message_type(&self) -> MessageType {
+        self.message_type
     }
 
     #[wasm_bindgen(getter)]

--- a/bindings/wasm/src/types/mod.rs
+++ b/bindings/wasm/src/types/mod.rs
@@ -630,10 +630,7 @@ impl From<ApiDetails> for Details {
     fn from(details: ApiDetails) -> Self {
         Self {
             metadata: details.metadata.into(),
-            milestone: match details.milestone {
-                Some(ms) => Some(ms.into()),
-                None => None,
-            },
+            milestone: details.milestone.map(|ms| ms.into()),
         }
     }
 }
@@ -707,10 +704,7 @@ impl From<ApiMessageMetadata> for MessageMetadata {
             is_solid: metadata.is_solid,
             referenced_by_milestone_index: metadata.referenced_by_milestone_index,
             milestone_index: metadata.milestone_index,
-            ledger_inclusion_state: match metadata.ledger_inclusion_state {
-                None => None,
-                Some(inc) => Some(inc.into()),
-            },
+            ledger_inclusion_state: metadata.ledger_inclusion_state.map(|inc| inc.into()),
             conflict_reason: metadata.conflict_reason,
             should_promote: metadata.should_promote,
             should_reattach: metadata.should_reattach,

--- a/bindings/wasm/src/user/userw.rs
+++ b/bindings/wasm/src/user/userw.rs
@@ -63,7 +63,6 @@ impl StreamsClient {
 }
 
 impl StreamsClient {
-    #[allow(clippy::wrong_self_convention)]
     pub fn into_inner(self) -> Rc<RefCell<ApiClient>> {
         self.0
     }

--- a/iota-streams-app-channels/src/api/key_store.rs
+++ b/iota-streams-app-channels/src/api/key_store.rs
@@ -71,8 +71,7 @@ impl<Info, F: PRP> KeyStore<Info, F> for KeyMap<Info> {
                 Identifier::PskId(_id) => self
                     .psks
                     .get_key_value(id)
-                    .map(|(e, (x, _))| x.map(|xx| (e, xx.to_vec())))
-                    .flatten(),
+                    .and_then(|(e, (x, _))| x.map(|xx| (e, xx.to_vec()))),
             })
             .collect()
     }


### PR DESCRIPTION
# Description of change

Add `UserResponse#messageType` property to let wasm users know which type of message they are receiving. 

closes #205 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

- `cd bindings/wasm && npm ci && npm run build:nodejs && npm run example:nodejs && npm run example:nodets && npm run unittest`


## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
