### PR TITLE
[V2.0] Lean State 

### DIFF
--- a/streams/examples/full-example/main.rs
+++ b/streams/examples/full-example/main.rs
@@ -40,7 +40,7 @@ async fn run_did_scenario<SR, T: GenericTransport<SR>>(transport: T) -> Result<(
     result
 }
 
-async fn run_lean_test<T: GenericTransport>(transport: T, seed: &str) -> Result<()> {
+async fn run_lean_test<SR, T: GenericTransport<SR>>(transport: T, seed: &str) -> Result<()> {
     println!("## Running Lean State Test ##\n");
     let result = scenarios::lean::example(transport, seed).await;
     match &result {
@@ -50,7 +50,7 @@ async fn run_lean_test<T: GenericTransport>(transport: T, seed: &str) -> Result<
     result
 }
 
-async fn run_basic_scenario<T: GenericTransport>(transport: T, seed: &str) -> Result<()> {
+async fn run_basic_scenario<SR, T: GenericTransport<SR>>(transport: T, seed: &str) -> Result<()> {
     println!("## Running single branch test with seed: {} ##\n", seed);
     let result = scenarios::basic::example(transport, seed).await;
     match &result {

--- a/streams/examples/full-example/main.rs
+++ b/streams/examples/full-example/main.rs
@@ -32,6 +32,16 @@ async fn run_did_test(transport: Rc<RefCell<tangle::Client>>) -> Result<()> {
     result
 }
 
+async fn run_lean_test<T: GenericTransport>(transport: T, seed: &str) -> Result<()> {
+    println!("## Running Lean State Test ##\n");
+    let result = scenarios::lean::example(transport, seed).await;
+    match &result {
+        Err(err) => eprintln!("Error in Lean State test: {:?}", err),
+        Ok(_) => println!("\n## Lean State test completed successfully!! ##\n"),
+    }
+    result
+}
+
 async fn run_single_branch_test<T: GenericTransport>(transport: T, seed: &str) -> Result<()> {
     println!("## Running single branch test with seed: {} ##\n", seed);
     let result = scenarios::basic::example(transport, seed).await;
@@ -55,6 +65,7 @@ async fn main_pure() -> Result<()> {
     let transport = Rc::new(RefCell::new(transport));
 
     run_single_branch_test(transport.clone(), "PURESEEDA").await?;
+    run_lean_test(transport, "PURESEEDB").await?;
     println!("################################################");
     println!("Done running pure tests without accessing Tangle");
     println!("################################################");
@@ -77,7 +88,8 @@ async fn main_client() -> Result<()> {
         )));
 
     run_single_branch_test(transport.clone(), &new_seed()).await?;
-    run_did_test(transport).await?;
+    run_did_test(transport.clone()).await?;
+    run_lean_test(transport, &new_seed()).await?;
     println!(
         "#############################################{}",
         "#".repeat(node_url.len())

--- a/streams/examples/full-example/scenarios/lean.rs
+++ b/streams/examples/full-example/scenarios/lean.rs
@@ -22,7 +22,7 @@ const BASE_BRANCH: &str = "BASE_BRANCH";
 const BRANCH1: &str = "BRANCH1";
 const BRANCH2: &str = "BRANCH2";
 
-pub(crate) async fn example<T: GenericTransport>(transport: T, author_seed: &str) -> Result<()> {
+pub(crate) async fn example<SR, T: GenericTransport<SR>>(transport: T, author_seed: &str) -> Result<()> {
     let psk = Psk::from_seed("unique psk seed");
 
     let mut author = User::builder()
@@ -97,7 +97,7 @@ pub(crate) async fn example<T: GenericTransport>(transport: T, author_seed: &str
     Ok(())
 }
 
-async fn sync_subs<T: GenericTransport>(fat: &mut User<T>, lean: &mut User<T>) -> Result<()> {
+async fn sync_subs<SR, T: GenericTransport<SR>>(fat: &mut User<T>, lean: &mut User<T>) -> Result<()> {
     print!("\nsubscribers syncing...");
     fat.sync().await?;
     lean.sync().await?;
@@ -112,7 +112,7 @@ async fn sync_subs<T: GenericTransport>(fat: &mut User<T>, lean: &mut User<T>) -
     Ok(())
 }
 
-async fn retrieve_messages<T: GenericTransport, TSR>(
+async fn retrieve_messages<SR, T: GenericTransport<SR>, TSR>(
     fat_subscriber: &mut User<T>,
     lean_subscriber: &mut User<T>,
     first_message: SendResponse<TSR>,

--- a/streams/examples/full-example/scenarios/lean.rs
+++ b/streams/examples/full-example/scenarios/lean.rs
@@ -30,16 +30,16 @@ pub(crate) async fn example<SR, T: GenericTransport<SR>>(transport: T, author_se
         .with_identity(Identity::Ed25519(Ed25519::from_seed(author_seed)))
         .with_psk(psk.to_pskid(), psk)
         .lean()
-        .build()?;
+        .build();
     let mut fat_subscriber = User::builder()
         .with_transport(transport.clone())
         .with_psk(psk.to_pskid(), psk)
-        .build()?;
+        .build();
     let mut lean_subscriber = User::builder()
         .with_transport(transport)
         .with_psk(psk.to_pskid(), psk)
         .lean()
-        .build()?;
+        .build();
 
     println!("author creates channel");
     let announcement = author.create_stream(BASE_BRANCH).await?;

--- a/streams/examples/full-example/scenarios/lean.rs
+++ b/streams/examples/full-example/scenarios/lean.rs
@@ -1,0 +1,167 @@
+// Rust
+
+// 3rd-party
+use anyhow::Result;
+use lets::id::Identity;
+
+// IOTA
+
+// Streams
+use streams::{
+    id::{Ed25519, Psk},
+    SendResponse, User,
+};
+
+// Local
+use crate::GenericTransport;
+
+const PUBLIC_PAYLOAD: &[u8] = b"PUBLICPAYLOAD";
+const MASKED_PAYLOAD: &[u8] = b"MASKEDPAYLOAD";
+
+const BASE_BRANCH: &str = "BASE_BRANCH";
+const BRANCH1: &str = "BRANCH1";
+const BRANCH2: &str = "BRANCH2";
+
+pub(crate) async fn example<T: GenericTransport>(transport: T, author_seed: &str) -> Result<()> {
+    let psk = Psk::from_seed("unique psk seed");
+
+    let mut author = User::builder()
+        .with_transport(transport.clone())
+        .with_identity(Identity::Ed25519(Ed25519::from_seed(author_seed)))
+        .with_psk(psk.to_pskid(), psk)
+        .lean()
+        .build()?;
+    let mut fat_subscriber = User::builder()
+        .with_transport(transport.clone())
+        .with_psk(psk.to_pskid(), psk)
+        .build()?;
+    let mut lean_subscriber = User::builder()
+        .with_transport(transport)
+        .with_psk(psk.to_pskid(), psk)
+        .lean()
+        .build()?;
+
+    println!("author creates channel");
+    let announcement = author.create_stream(BASE_BRANCH).await?;
+
+    fat_subscriber.receive_message(announcement.address()).await?;
+    lean_subscriber.receive_message(announcement.address()).await?;
+
+    println!("author sends a few messages to the base branch");
+    let first_message = author
+        .send_signed_packet(BASE_BRANCH, PUBLIC_PAYLOAD, MASKED_PAYLOAD)
+        .await?;
+    let _second_message = author
+        .send_signed_packet(BASE_BRANCH, PUBLIC_PAYLOAD, MASKED_PAYLOAD)
+        .await?;
+    let middle_message = author
+        .send_signed_packet(BASE_BRANCH, PUBLIC_PAYLOAD, MASKED_PAYLOAD)
+        .await?;
+    let _third_message = author
+        .send_signed_packet(BASE_BRANCH, PUBLIC_PAYLOAD, MASKED_PAYLOAD)
+        .await?;
+    let last_message = author
+        .send_signed_packet(BASE_BRANCH, PUBLIC_PAYLOAD, MASKED_PAYLOAD)
+        .await?;
+
+    // sync subscribers to retrieve all available messages
+    sync_subs(&mut fat_subscriber, &mut lean_subscriber).await?;
+    // each subscriber tries to retrieve specific messages from the branch
+    retrieve_messages(
+        &mut fat_subscriber,
+        &mut lean_subscriber,
+        first_message,
+        middle_message,
+        last_message,
+    )
+    .await?;
+
+    println!("author creates 2 new branch and sends messages to each one");
+    author.new_branch(BASE_BRANCH, BRANCH1).await?;
+    for _ in 0..20 {
+        author
+            .send_signed_packet(BRANCH1, PUBLIC_PAYLOAD, MASKED_PAYLOAD)
+            .await?;
+    }
+
+    author.new_branch(BASE_BRANCH, BRANCH2).await?;
+    for _ in 0..20 {
+        author
+            .send_signed_packet(BRANCH2, PUBLIC_PAYLOAD, MASKED_PAYLOAD)
+            .await?;
+    }
+
+    // sync the subscribers again and compare user size
+    sync_subs(&mut fat_subscriber, &mut lean_subscriber).await?;
+
+    Ok(())
+}
+
+async fn sync_subs<T: GenericTransport>(fat: &mut User<T>, lean: &mut User<T>) -> Result<()> {
+    print!("\nsubscribers syncing...");
+    fat.sync().await?;
+    lean.sync().await?;
+    println!("done");
+
+    let fat_backup = fat.backup("password").await?;
+    let lean_backup = lean.backup("password").await?;
+
+    assert!(fat_backup.len() > lean_backup.len());
+    println!("\tlean backup size: {} Bytes", lean_backup.len());
+    println!("\tfat backup size: {} Bytes\n", fat_backup.len());
+    Ok(())
+}
+
+async fn retrieve_messages<T: GenericTransport, TSR>(
+    fat_subscriber: &mut User<T>,
+    lean_subscriber: &mut User<T>,
+    first_message: SendResponse<TSR>,
+    middle_message: SendResponse<TSR>,
+    last_message: SendResponse<TSR>,
+) -> Result<()> {
+    println!("\nfat subscriber tries to retrieve first, middle and last messages...");
+    // The fat subscriber will be able to retrieve any previously received message again, as all
+    // spongos states remainn stored in the user implementation
+    let received_first_message_as_fat = fat_subscriber.receive_message(first_message.address()).await;
+    assert!(
+        received_first_message_as_fat.is_ok(),
+        "fat subscriber should be able to read the first message in base branch"
+    );
+    let received_second_message_as_fat = fat_subscriber.receive_message(middle_message.address()).await;
+    assert!(
+        received_second_message_as_fat.is_ok(),
+        "fat subscriber should be able to read the middle message in base branch"
+    );
+    let received_last_message_as_fat = fat_subscriber.receive_message(last_message.address()).await;
+    assert!(
+        received_last_message_as_fat.is_ok(),
+        "fat subscriber should be able to read the third message in base branch"
+    );
+    println!("fat subscriber was able to retrieve all three messages");
+
+    println!("\nlean subscriber tries to retrieve first, middle and last messages...");
+    // The lean subscriber will be able to receive the first message because it is linked to the
+    // announcement message, who's spongos state will always be stored
+    let received_first_message_as_lean = lean_subscriber.receive_message(first_message.address()).await;
+    assert!(
+        received_first_message_as_lean.is_ok(),
+        "lean subscriber should be able to read the first message"
+    );
+    // The lean subscriber will not be able to receive the middle message because it is linked to a
+    // pruned spongos state (first_message)
+    let received_second_message_as_lean = lean_subscriber.receive_message(middle_message.address()).await?;
+    assert!(
+        received_second_message_as_lean.is_orphan(),
+        "lean subscriber should not be able to read the middle message"
+    );
+    // The lean subscriber will also be able to receive the last message, because it is the latest
+    // spongos state to have been stored
+    let received_last_message_as_lean = lean_subscriber.receive_message(last_message.address()).await;
+    assert!(
+        received_last_message_as_lean.is_ok(),
+        "lean subscriber should be able to read the last message"
+    );
+    println!("lean subscriber was able to read first and last message, but not the middle, as expected\n");
+
+    Ok(())
+}

--- a/streams/examples/full-example/scenarios/mod.rs
+++ b/streams/examples/full-example/scenarios/mod.rs
@@ -1,4 +1,5 @@
 pub mod basic;
 #[cfg(feature = "did")]
 pub mod did;
+pub mod lean;
 pub mod utils;

--- a/streams/src/api/user_builder.rs
+++ b/streams/src/api/user_builder.rs
@@ -85,7 +85,6 @@ impl<T> UserBuilder<T> {
         }
     }
 
-
     /// Inject a new Pre Shared Key and Id into the User Builder
     ///
     /// # Examples

--- a/streams/src/api/user_builder.rs
+++ b/streams/src/api/user_builder.rs
@@ -26,6 +26,8 @@ pub struct UserBuilder<T> {
     transport: Option<T>,
     /// Pre Shared Keys
     psks: Vec<(PskId, Psk)>,
+    /// Spongos Storage Type
+    lean: bool,
 }
 
 impl<T> Default for UserBuilder<T> {
@@ -34,6 +36,7 @@ impl<T> Default for UserBuilder<T> {
             id: None,
             transport: None,
             psks: Default::default(),
+            lean: false,
         }
     }
 }
@@ -58,6 +61,12 @@ impl<T> UserBuilder<T> {
         self
     }
 
+    /// Set the User Builder lean state to true
+    pub fn lean(mut self) -> Self {
+        self.lean = true;
+        self
+    }
+
     /// Inject Transport Client instance into the User Builder
     ///
     /// # Arguments
@@ -70,6 +79,7 @@ impl<T> UserBuilder<T> {
             transport: Some(transport),
             id: self.id,
             psks: self.psks,
+            lean: self.lean,
         }
     }
 
@@ -84,6 +94,7 @@ impl<T> UserBuilder<T> {
             transport: Some(NewTransport::try_default().await?),
             id: self.id,
             psks: self.psks,
+            lean: self.lean,
         })
     }
 
@@ -152,7 +163,7 @@ impl<T> UserBuilder<T> {
             .transport
             .ok_or_else(|| anyhow!("transport not specified, cannot build User without Transport"))?;
 
-        Ok(User::new(self.id, self.psks, transport))
+        Ok(User::new(self.id, self.psks, transport, self.lean))
     }
 
     /// Recover a user instance from the builder parameters.
@@ -186,8 +197,7 @@ impl<T> UserBuilder<T> {
     /// # async fn main() -> Result<()> {
     /// # let test_transport = Rc::new(RefCell::new(bucket::Client::new()));
     /// let author_seed = "author_secure_seed";
-    /// let transport: tangle::Client =
-    ///     tangle::Client::for_node("https://chrysalis-nodes.iota.org").await?;
+    /// let transport: tangle::Client = tangle::Client::for_node("https://chrysalis-nodes.iota.org").await?;
     /// #
     /// # let transport = test_transport.clone();
     /// # let mut author = User::builder()

--- a/streams/src/api/user_builder.rs
+++ b/streams/src/api/user_builder.rs
@@ -197,7 +197,8 @@ impl<T> UserBuilder<T> {
     /// # async fn main() -> Result<()> {
     /// # let test_transport = Rc::new(RefCell::new(bucket::Client::new()));
     /// let author_seed = "author_secure_seed";
-    /// let transport: tangle::Client = tangle::Client::for_node("https://chrysalis-nodes.iota.org").await?;
+    /// let transport: tangle::Client =
+    ///     tangle::Client::for_node("https://chrysalis-nodes.iota.org").await?;
     /// #
     /// # let transport = test_transport.clone();
     /// # let mut author = User::builder()

--- a/streams/src/api/user_builder.rs
+++ b/streams/src/api/user_builder.rs
@@ -138,7 +138,6 @@ impl<T> UserBuilder<T> {
     /// let user_seed = "cryptographically-secure-random-user-seed";
     /// let mut user = User::builder()
     ///     .with_identity(Ed25519::from_seed(user_seed))
-    ///     .with_identity(Ed25519::from_seed(user_seed))
     ///     .build();
     ///
     /// # Ok(())
@@ -150,7 +149,7 @@ impl<T> UserBuilder<T> {
         T: IntoTransport<Trans>,
         Trans: for<'a> Transport<'a>,
     {
-        User::new(self.id, self.psks, self.transport.into())
+        User::new(self.id, self.psks, self.transport.into(), self.lean)
     }
 
     /// Recover a user instance from the builder parameters.


### PR DESCRIPTION
# Description of change

Adds a lean state option to the `UserBuilder`, allowing a `User` to be configured to only store necessary message spongos. As a default a `User` stores all spongos states that it processes, so that linked messages can be read at any time later, but this creates a lot of additional bloat for the `User` as it continues to receive and send messages. This feature is beneficial for implementations that publish frequently in many branches, but have no need to read messages that have already been processed. The `User` can maintain synchronization with the channel while minimizing their overall memory usage over time significantly. 


### Benchmark
```
Fat User:

	1 branches, 10 messages per: 2871 Bytes
	1 branches, 100 messages per: 21951 Bytes
	1 branches, 1000 messages per: 212753 Bytes
	1 branches, 10000 messages per: 2120753 Bytes

	10 branches, 10 messages per: 24391 Bytes
	10 branches, 100 messages per: 215192 Bytes
	10 branches, 1000 messages per: 2123202 Bytes
	10 branches, 10000 messages per: 21203203 Bytes

	100 branches, 10 messages per: 239673 Bytes
	100 branches, 100 messages per: 2147673 Bytes
	100 branches, 1000 messages per: 21227774 Bytes
	100 branches, 10000 messages per: 212027774 Bytes

	250 branches, 10 messages per: 598623 Bytes
	250 branches, 100 messages per: 5368623 Bytes
	250 branches, 1000 messages per: 53068874 Bytes
	250 branches, 10000 messages per: 530068874 Bytes


Lean User:

	1 branches, 10 messages per: 751 Bytes
	1 branches, 100 messages per: 751 Bytes
	1 branches, 1000 messages per: 752 Bytes
	1 branches, 10000 messages per: 752 Bytes

	10 branches, 10 messages per: 3191 Bytes
	10 branches, 100 messages per: 3191 Bytes
	10 branches, 1000 messages per: 3201 Bytes
	10 branches, 10000 messages per: 3201 Bytes

	100 branches, 10 messages per: 27672 Bytes
	100 branches, 100 messages per: 27672 Bytes
	100 branches, 1000 messages per: 27772 Bytes
	100 branches, 10000 messages per: 27772 Bytes

	250 branches, 10 messages per: 68622 Bytes
	250 branches, 100 messages per: 68622 Bytes
	250 branches, 1000 messages per: 68872 Bytes
	250 branches, 10000 messages per: 68872 Bytes
```


## Type of change
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested
- previous examples continue to pass 
- new example created for state size comparisons
- cargo test
- benchmarking
