### PR TITLE
[V2.0] Message Builder

### DIFF
--- a/lets/src/message/topic.rs
+++ b/lets/src/message/topic.rs
@@ -25,12 +25,6 @@ impl Topic {
     }
 }
 
-impl From<&Topic> for Topic {
-    fn from(t: &Topic) -> Self {
-        t.clone()
-    }
-}
-
 impl From<&str> for Topic {
     fn from(t: &str) -> Self {
         Self(t.to_string())

--- a/lets/src/message/topic.rs
+++ b/lets/src/message/topic.rs
@@ -25,6 +25,12 @@ impl Topic {
     }
 }
 
+impl From<&Topic> for Topic {
+    fn from(t: &Topic) -> Self {
+        t.clone()
+    }
+}
+
 impl From<&str> for Topic {
     fn from(t: &str) -> Self {
         Self(t.to_string())

--- a/streams/examples/full-example/scenarios/basic.rs
+++ b/streams/examples/full-example/scenarios/basic.rs
@@ -236,7 +236,11 @@ pub(crate) async fn example<SR, T: GenericTransport<SR>>(transport: T, author_se
 
     println!("> Author sends a signed packet");
     let signed_packet_as_author = author
-        .send_signed_packet(BRANCH1, PUBLIC_PAYLOAD, MASKED_PAYLOAD)
+        .message()
+        .with_topic(BRANCH1)
+        .with_payload(PUBLIC_PAYLOAD)
+        .public()
+        .send()
         .await?;
     print_send_result(&signed_packet_as_author);
     print_user("Author", &author);
@@ -252,11 +256,11 @@ pub(crate) async fn example<SR, T: GenericTransport<SR>>(transport: T, author_se
             .expect("expected a message with public payload, found something else"),
         PUBLIC_PAYLOAD
     );
-    assert_eq!(
+    assert!(
         signed_packet_as_b
             .masked_payload()
-            .expect("expected a message with masked payload, found something else"),
-        MASKED_PAYLOAD
+            .expect("expected a message with masked payload, found something else")
+            .is_empty()
     );
 
     assert_eq!(author.sync().await?, 0);

--- a/streams/examples/full-example/scenarios/basic.rs
+++ b/streams/examples/full-example/scenarios/basic.rs
@@ -166,7 +166,10 @@ pub(crate) async fn example<SR, T: GenericTransport<SR>>(transport: T, author_se
 
     println!("> Author sends a tagged packet linked to the keyload");
     let tagged_packet_as_author = author
-        .send_tagged_packet(BRANCH1, PUBLIC_PAYLOAD, MASKED_PAYLOAD)
+        .message()
+        .with_topic(BRANCH1)
+        .with_payload(MASKED_PAYLOAD)
+        .send()
         .await?;
     print_send_result(&tagged_packet_as_author);
     print_user("Author", &author);
@@ -178,11 +181,11 @@ pub(crate) async fn example<SR, T: GenericTransport<SR>>(transport: T, author_se
         .await?
         .expect("subscriber A did not receive the tagged packet sent by Author");
     print_user("Subscriber A", &subscriber_a);
-    assert_eq!(
+    assert!(
         tagged_packet_as_a
             .public_payload()
-            .expect("expected a message with public payload, found something else"),
-        PUBLIC_PAYLOAD
+            .expect("expected a message with public payload, found something else")
+            .is_empty()
     );
     assert_eq!(
         tagged_packet_as_a
@@ -198,11 +201,11 @@ pub(crate) async fn example<SR, T: GenericTransport<SR>>(transport: T, author_se
         .await?
         .expect("subscriber C did not receive the tagged packet sent by subscriber A");
     print_user("Subscriber C", &subscriber_c);
-    assert_eq!(
+    assert!(
         tagged_packet_as_c
             .public_payload()
-            .expect("expected a message with public payload, found something else"),
-        PUBLIC_PAYLOAD
+            .expect("expected a message with public payload, found something else")
+            .is_empty()
     );
     assert_eq!(
         tagged_packet_as_c

--- a/streams/examples/full-example/scenarios/lean.rs
+++ b/streams/examples/full-example/scenarios/lean.rs
@@ -47,36 +47,11 @@ pub(crate) async fn example<SR, T: GenericTransport<SR>>(transport: T, author_se
     lean_subscriber.receive_message(announcement.address()).await?;
 
     println!("author sends a few messages to the base branch");
-    let first_message = author
-        .message()
-        .with_payload(PAYLOAD)
-        .signed()
-        .send()
-        .await?;
-    let _second_message = author
-        .message()
-        .with_payload(PAYLOAD)
-        .signed()
-        .send()
-        .await?;
-    let middle_message = author
-        .message()
-        .with_payload(PAYLOAD)
-        .signed()
-        .send()
-        .await?;
-    let _third_message = author
-        .message()
-        .with_payload(PAYLOAD)
-        .signed()
-        .send()
-        .await?;
-    let last_message = author
-        .message()
-        .with_payload(PAYLOAD)
-        .signed()
-        .send()
-        .await?;
+    let first_message = author.message().with_payload(PAYLOAD).signed().send().await?;
+    let _second_message = author.message().with_payload(PAYLOAD).signed().send().await?;
+    let middle_message = author.message().with_payload(PAYLOAD).signed().send().await?;
+    let _third_message = author.message().with_payload(PAYLOAD).signed().send().await?;
+    let last_message = author.message().with_payload(PAYLOAD).signed().send().await?;
 
     // sync subscribers to retrieve all available messages
     sync_subs(&mut fat_subscriber, &mut lean_subscriber).await?;

--- a/streams/examples/full-example/scenarios/lean.rs
+++ b/streams/examples/full-example/scenarios/lean.rs
@@ -15,8 +15,7 @@ use streams::{
 // Local
 use crate::GenericTransport;
 
-const PUBLIC_PAYLOAD: &[u8] = b"PUBLICPAYLOAD";
-const MASKED_PAYLOAD: &[u8] = b"MASKEDPAYLOAD";
+const PAYLOAD: &[u8] = b"MASKEDPAYLOAD";
 
 const BASE_BRANCH: &str = "BASE_BRANCH";
 const BRANCH1: &str = "BRANCH1";
@@ -49,19 +48,34 @@ pub(crate) async fn example<SR, T: GenericTransport<SR>>(transport: T, author_se
 
     println!("author sends a few messages to the base branch");
     let first_message = author
-        .send_signed_packet(BASE_BRANCH, PUBLIC_PAYLOAD, MASKED_PAYLOAD)
+        .message()
+        .with_payload(PAYLOAD)
+        .signed()
+        .send()
         .await?;
     let _second_message = author
-        .send_signed_packet(BASE_BRANCH, PUBLIC_PAYLOAD, MASKED_PAYLOAD)
+        .message()
+        .with_payload(PAYLOAD)
+        .signed()
+        .send()
         .await?;
     let middle_message = author
-        .send_signed_packet(BASE_BRANCH, PUBLIC_PAYLOAD, MASKED_PAYLOAD)
+        .message()
+        .with_payload(PAYLOAD)
+        .signed()
+        .send()
         .await?;
     let _third_message = author
-        .send_signed_packet(BASE_BRANCH, PUBLIC_PAYLOAD, MASKED_PAYLOAD)
+        .message()
+        .with_payload(PAYLOAD)
+        .signed()
+        .send()
         .await?;
     let last_message = author
-        .send_signed_packet(BASE_BRANCH, PUBLIC_PAYLOAD, MASKED_PAYLOAD)
+        .message()
+        .with_payload(PAYLOAD)
+        .signed()
+        .send()
         .await?;
 
     // sync subscribers to retrieve all available messages
@@ -80,14 +94,22 @@ pub(crate) async fn example<SR, T: GenericTransport<SR>>(transport: T, author_se
     author.new_branch(BASE_BRANCH, BRANCH1).await?;
     for _ in 0..20 {
         author
-            .send_signed_packet(BRANCH1, PUBLIC_PAYLOAD, MASKED_PAYLOAD)
+            .message()
+            .with_topic(BRANCH1)
+            .with_payload(PAYLOAD)
+            .signed()
+            .send()
             .await?;
     }
 
     author.new_branch(BASE_BRANCH, BRANCH2).await?;
     for _ in 0..20 {
         author
-            .send_signed_packet(BRANCH2, PUBLIC_PAYLOAD, MASKED_PAYLOAD)
+            .message()
+            .with_topic(BRANCH2)
+            .with_payload(PAYLOAD)
+            .signed()
+            .send()
             .await?;
     }
 

--- a/streams/src/api/message_builder.rs
+++ b/streams/src/api/message_builder.rs
@@ -89,6 +89,7 @@ impl<'a, P, Trans> MessageBuilder<'a, P, Trans> {
     /// # let user_seed = "cryptographically-secure-random-user-seed";
     /// # let mut user = User::builder()
     /// #    .with_identity(Ed25519::from_seed(user_seed))
+    /// #    .with_transport(bucket::Client::new())
     /// #    .build();
     /// #
     /// let topic = "Branch 1";
@@ -138,7 +139,7 @@ impl<'a, P, Trans> MessageBuilder<'a, P, Trans> {
 mod message_builder_tests {
     use crate::{api::message_builder::MessageBuilder, User};
     use lets::{
-        id::{Ed25519, Identity},
+        id::Ed25519,
         message::Topic,
         transport::bucket,
     };

--- a/streams/src/api/message_builder.rs
+++ b/streams/src/api/message_builder.rs
@@ -88,9 +88,7 @@ impl<'a, P, Trans> MessageBuilder<'a, P, Trans> {
     /// # let user_seed = "cryptographically-secure-random-user-seed";
     /// # let mut user = User::builder()
     /// #    .with_identity(Ed25519::from_seed(user_seed))
-    /// #    .with_default_transport::<bucket::Client>()
-    /// #    .await?
-    /// #    .build()?;
+    /// #    .build();
     /// #
     /// let topic = "Branch 1";
     /// # user.create_stream(topic).await?;
@@ -150,8 +148,7 @@ mod message_builder_tests {
         let mut user = User::builder()
             .with_transport(bucket::Client::new())
             .with_identity(Identity::Ed25519(Ed25519::from_seed("user seed")))
-            .build()
-            .unwrap();
+            .build();
 
         user.create_stream(BASE_BRANCH)
             .await

--- a/streams/src/api/message_builder.rs
+++ b/streams/src/api/message_builder.rs
@@ -138,11 +138,7 @@ impl<'a, P, Trans> MessageBuilder<'a, P, Trans> {
 #[cfg(test)]
 mod message_builder_tests {
     use crate::{api::message_builder::MessageBuilder, User};
-    use lets::{
-        id::Ed25519,
-        message::Topic,
-        transport::bucket,
-    };
+    use lets::{id::Ed25519, message::Topic, transport::bucket};
 
     const BASE_BRANCH: &str = "Base Branch";
 

--- a/streams/src/api/message_builder.rs
+++ b/streams/src/api/message_builder.rs
@@ -1,0 +1,278 @@
+use anyhow::{anyhow, Result};
+use lets::message::{Topic, TransportMessage};
+use lets::transport::Transport;
+use crate::{SendResponse, User};
+
+/// A builder for creating messages for transport
+pub struct MessageBuilder<'a, P, Trans> {
+    /// A User Client to send the message from
+    user: &'a mut User<Trans>,
+    /// Whether or not the message payload will be masked in transit (defaults to masked)
+    private: bool,
+    /// Whether or not the message will be signed by the user sending (defaults to unsigned)
+    signed: bool,
+    /// The Topic of the branch the message will be sent to (defaults to the base branch)
+    topic: Topic,
+    /// A payload to be sent to the channel
+    payload: P,
+}
+
+impl<'a, P, Trans> MessageBuilder<'a, P, Trans> {
+    /// Creates a new MessageBuilder from an existing User Client
+    ///
+    /// # Arguments
+    /// * user - User Client that will send the message
+    pub fn new(user: &'a mut User<Trans>) -> Self
+    where
+        P: Default
+    {
+        let topic = user.base_branch().into();
+        MessageBuilder {
+            user,
+            private: true,
+            signed: false,
+            topic,
+            payload: P::default()
+        }
+    }
+
+    /// Sets the private flag to false, so the message will not be masked in transit
+    pub fn public(mut self) -> Self {
+        self.private = false;
+        self
+    }
+
+    /// Sets the signed flag to true, so the User will sign the message
+    pub fn signed(mut self) -> Self {
+        self.signed = true;
+        self
+    }
+
+    /// Inject the data payload into the builder. The payload cannot be empty and must be able to be
+    /// referenced as an unsigned byte array.
+    ///
+    /// # Arguments
+    /// * payload - The data payload that will be sent
+    pub fn with_payload(mut self, payload: P) -> Self
+    where
+        P: AsRef<[u8]>,
+    {
+        self.payload = payload;
+        self
+    }
+
+    /// Inject the Topic of the branch into the builder. The default topic is the base branch topic
+    /// of the User Client.
+    ///
+    /// # Arguments
+    /// * topic - The topic of the branch the message will be sent to
+    pub fn with_topic<Top: Into<Topic>>(mut self, topic: Top) -> Self {
+        self.topic = topic.into();
+        self
+    }
+
+
+    /// Sends the message payload to the specified branch using the User Client. If the message is
+    /// signed, the message will be sent as a Signed Packet, and if not, it will be sent as a
+    /// Tagged Packet.
+    ///
+    ///
+    /// # Examples
+    /// ## Send Signed Message
+    /// ```
+    /// # use anyhow::Result;
+    /// # use streams::{id::Ed25519, transport::bucket, User};
+    /// #
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<()> {
+    /// # let user_seed = "cryptographically-secure-random-user-seed";
+    /// # let mut user = User::builder()
+    /// #    .with_identity(Ed25519::from_seed(user_seed))
+    /// #    .with_default_transport::<bucket::Client>()
+    /// #    .await?
+    /// #    .build()?;
+    /// #
+    /// let topic = "Branch 1";
+    /// # user.create_stream(topic).await?;
+    /// let payload = "A Data Payload";
+    ///
+    /// let message = user.message()
+    ///     .with_topic(topic)
+    ///     .with_payload(payload)
+    ///     .signed()
+    ///     .send()
+    ///     .await?;
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn send<TSR>(self) -> Result<SendResponse<TSR>>
+    where
+        P: AsRef<[u8]>,
+        Trans: for<'b> Transport<'b, Msg = TransportMessage, SendResponse = TSR>
+    {
+        if self.payload.as_ref().is_empty() {
+            return Err(anyhow!("message payload cannot be empty"))
+        }
+
+        let mut public: &[u8] = &[];
+        let mut private: &[u8]= &[];
+
+        if self.private {
+            private = self.payload.as_ref()
+        } else {
+            public = self.payload.as_ref()
+        }
+
+        let user: &mut User<Trans> = self.user;
+        let topic = user.base_branch().clone();
+        if self.signed {
+            user.send_signed_packet(&topic, public, private).await
+        } else {
+            user.send_tagged_packet(self.topic, public, private).await
+        }
+    }
+}
+
+
+
+#[cfg(test)]
+mod message_builder_tests {
+    use lets::id::{Ed25519, Identity};
+    use lets::message::Topic;
+    use crate::User;
+    use lets::transport::bucket;
+    use crate::api::message_builder::MessageBuilder;
+
+    const BASE_BRANCH: &str = "Base Branch";
+
+    async fn make_user() -> User<bucket::Client> {
+        let mut user = User::builder()
+            .with_transport(bucket::Client::new())
+            .with_identity(Identity::Ed25519(Ed25519::from_seed("user seed")))
+            .build()
+            .unwrap();
+
+        user.create_stream(BASE_BRANCH)
+            .await
+            .unwrap();
+
+        user
+
+    }
+
+    #[tokio::test]
+    async fn make_message() {
+        let topic = "A message topic";
+        let payload = "A payload";
+        let raw_payload = [80_u8, 97, 121, 108, 111, 97, 100];
+
+        let mut user = make_user().await;
+        user.new_branch(BASE_BRANCH, topic).await.unwrap();
+
+        let str_message = MessageBuilder::new(&mut user)
+            .with_payload(payload)
+            .signed()
+            .public();
+
+        assert!(!str_message.private);
+        assert!(str_message.signed);
+        assert_eq!(Topic::from(BASE_BRANCH), str_message.topic);
+        assert_eq!(payload, str_message.payload);
+
+        let raw_message = MessageBuilder::new(&mut user)
+            .with_payload(raw_payload)
+            .with_topic(topic);
+
+        assert!(raw_message.private);
+        assert!(!raw_message.signed);
+        assert_eq!(Topic::from(topic), raw_message.topic);
+        assert_eq!(raw_payload, raw_message.payload);
+    }
+
+    #[tokio::test]
+    async fn empty_payload_message() {
+        let mut user = make_user().await;
+
+        let message = user.message()
+            .with_payload(vec![])
+            .send()
+            .await;
+
+        assert!(message.is_err());
+    }
+
+        #[tokio::test]
+    async fn send_signed_messages() {
+        let mut user = make_user().await;
+        let priv_payload = "A Private Payload";
+        let pub_payload = "A Public Payload";
+
+        let private_msg = MessageBuilder::new(&mut user)
+            .with_payload(priv_payload)
+            .signed()
+            .send()
+            .await
+            .unwrap();
+
+        let public_msg = MessageBuilder::new(&mut user)
+            .with_payload(pub_payload)
+            .signed()
+            .public()
+            .send()
+            .await
+            .unwrap();
+
+        let received_private_msg = user.receive_message(private_msg.address())
+            .await
+            .unwrap();
+
+        let received_public_msg = user.receive_message(public_msg.address())
+            .await
+            .unwrap();
+
+        assert!(received_private_msg.is_signed_packet());
+        assert_eq!(received_private_msg.as_signed_packet().unwrap().masked_payload, priv_payload.as_bytes());
+        assert!(received_private_msg.as_signed_packet().unwrap().public_payload.is_empty());
+
+        assert!(received_public_msg.is_signed_packet());
+        assert_eq!(received_public_msg.as_signed_packet().unwrap().public_payload, pub_payload.as_bytes());
+        assert!(received_public_msg.as_signed_packet().unwrap().masked_payload.is_empty());
+    }
+
+    #[tokio::test]
+    async fn send_tagged_messages() {
+        let mut user = make_user().await;
+        let priv_payload = "A Private Payload";
+        let pub_payload = "A Public Payload";
+
+        let private_msg = MessageBuilder::new(&mut user)
+            .with_payload(priv_payload)
+            .send()
+            .await
+            .unwrap();
+
+        let public_msg = MessageBuilder::new(&mut user)
+            .with_payload(pub_payload)
+            .public()
+            .send()
+            .await
+            .unwrap();
+
+        let received_private_msg = user.receive_message(private_msg.address())
+            .await
+            .unwrap();
+
+        let received_public_msg = user.receive_message(public_msg.address())
+            .await
+            .unwrap();
+
+        assert!(received_private_msg.is_tagged_packet());
+        assert_eq!(received_private_msg.as_tagged_packet().unwrap().masked_payload, priv_payload.as_bytes());
+        assert!(received_private_msg.as_tagged_packet().unwrap().public_payload.is_empty());
+
+        assert!(received_public_msg.is_tagged_packet());
+        assert_eq!(received_public_msg.as_tagged_packet().unwrap().public_payload, pub_payload.as_bytes());
+        assert!(received_public_msg.as_tagged_packet().unwrap().masked_payload.is_empty());
+    }
+}

--- a/streams/src/api/message_builder.rs
+++ b/streams/src/api/message_builder.rs
@@ -148,7 +148,7 @@ mod message_builder_tests {
     async fn make_user() -> User<bucket::Client> {
         let mut user = User::builder()
             .with_transport(bucket::Client::new())
-            .with_identity(Identity::Ed25519(Ed25519::from_seed("user seed")))
+            .with_identity(Ed25519::from_seed("user seed"))
             .build();
 
         user.create_stream(BASE_BRANCH).await.unwrap();

--- a/streams/src/api/message_builder.rs
+++ b/streams/src/api/message_builder.rs
@@ -28,7 +28,7 @@ impl<'a, P, Trans> MessageBuilder<'a, P, Trans> {
     where
         P: Default,
     {
-        let topic = user.base_branch().into();
+        let topic = user.base_branch().clone();
         MessageBuilder {
             user,
             private: true,
@@ -125,12 +125,10 @@ impl<'a, P, Trans> MessageBuilder<'a, P, Trans> {
             public = self.payload.as_ref()
         }
 
-        let user: &mut User<Trans> = self.user;
-        let topic = user.base_branch().clone();
         if self.signed {
-            user.send_signed_packet(&topic, public, private).await
+            self.user.send_signed_packet(self.topic, public, private).await
         } else {
-            user.send_tagged_packet(self.topic, public, private).await
+            self.user.send_tagged_packet(self.topic, public, private).await
         }
     }
 }

--- a/streams/src/api/mod.rs
+++ b/streams/src/api/mod.rs
@@ -1,9 +1,15 @@
 /// Identifier Key storage. Used for keeping track of channel state
 mod cursor_store;
 
+/// Unwrapped Message Types
 pub(crate) mod message;
+/// Message builder for sending payloads
+mod message_builder;
+/// Message Retrieval
 mod messages;
+/// Message Wrapper for Sent Messages
 pub(crate) mod send_response;
 /// User Client
 pub(crate) mod user;
+/// User Client Builder
 pub(crate) mod user_builder;

--- a/streams/src/api/user.rs
+++ b/streams/src/api/user.rs
@@ -35,6 +35,7 @@ use crate::{
     api::{
         cursor_store::{CursorStore, InnerCursorStore},
         message::Message,
+        message_builder::MessageBuilder,
         messages::Messages,
         send_response::SendResponse,
         user_builder::UserBuilder,
@@ -1037,6 +1038,10 @@ where
             psks,
         )
         .await
+    }
+
+    pub fn message<P: Default>(&mut self) -> MessageBuilder<P, T> {
+        MessageBuilder::new(self)
     }
 
     pub async fn send_signed_packet<P, M, Top>(


### PR DESCRIPTION
# Description of change
Adds a `MessageBuilder` tool to `User`, allowing a user to build their message in builder pattern, sending the appropriate type of message dependent on the builder values. The default when instantiating the builder with `user.message()` will be directed at the base branch of the channel as a masked payload tagged packet.


### Examples  

#### Basic Single Branch Style Message (Tagged Packet)
```
user.message()
    .with_payload(raw_data)
    .send()
    .await?;
```

#### Signed Private Message (Signed Packet)
```
user.message()
    .with_topic(branch_topic)
    .with_payload(raw_data)
    .signed()
    .send()
    .await?;
```
#### Unsigned Public Message (Tagged Packet)
```
user.message()
    .with_topic(branch_topic)
    .with_payload(raw_data)
    .public()
    .send()
    .await?;
```


## Type of change
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested
- Unit tests added
- Previous tests continue to pass
- Examples augmented to mix usage of granular and builder methods

