### PR TITLE
Small Change to Dependency Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Add the following to your `Cargo.toml` file:
 ```bash
 [dependencies]
 anyhow = { version = "1.0", default-features = false }
-iota-streams = { git = "https://github.com/iotaledger/streams", branch  = "develop"}
+streams = { git = "https://github.com/iotaledger/streams", branch  = "develop"}
 ```
 
 **Local**


### PR DESCRIPTION
The project is called streams... It only works as streams you need to refactor the repository or just update this line in the docs to be correct.

# Description of change

The import says `iota-streams` which is probably what you want but that fails. The project is currently called `streams`. I am just correcting it and showing the project the issue. 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Documentation Fix

## How the change has been tested

I tested it. 
